### PR TITLE
chore: add harfbuzz to Homebrew installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ Nightly releases built with CrabNebula Cloud can be found at [releases](https://
 ## Future Work
 
 - Add more window and servo features to make it feel more like a general web browser.
-- Improve  development experience.
+- Improve development experience.
 - Multi webviews and multi browsing contexts in the same window.
+- Enable `Gstreamer` feature and remove `brew install harfbuzz` in README.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ scoop install git python llvm cmake curl
 - Install [Homebrew](https://brew.sh/) and then install other tools:
 
 ```sh
-brew install cmake pkg-config
+brew install cmake pkg-config harfbuzz
 ```
 
 ### Linux


### PR DESCRIPTION
I got error when running `cargo run`

```bash
pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags harfbuzz

  The system library `harfbuzz` required by crate `harfbuzz-sys` was not found.
  The file `harfbuzz.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  The PKG_CONFIG_PATH environment variable is not set.

  HINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `harfbuzz.pc`.

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Should we tell the user to install `harfbuzz`?