### PR TITLE
generate and deploy docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,93 @@
+name: Generate docs
+
+on:
+  push:
+    branches:
+      - main
+      - ops/doc # for testing on feature branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      CCACHE: sccache
+      SCCACHE_GHA_ENABLED: 'true'
+      LIBCLANG_PATH: /usr/lib/llvm-14/lib
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install build-essential python3-pip ccache clang cmake curl \
+            g++ git gperf libdbus-1-dev libfreetype6-dev libgl1-mesa-dri \
+            libgles2-mesa-dev libglib2.0-dev libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-good libgstreamer-plugins-good1.0-dev \
+            gstreamer1.0-plugins-bad libgstreamer-plugins-bad1.0-dev \
+            gstreamer1.0-plugins-ugly gstreamer1.0-plugins-base \
+            libgstreamer-plugins-base1.0-dev gstreamer1.0-libav \
+            libgstrtspserver-1.0-dev gstreamer1.0-tools libges-1.0-dev \
+            libharfbuzz-dev liblzma-dev libunwind-dev libunwind-dev libvulkan1 \
+            libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
+            libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway
+
+      - name: Run sccache-cache
+        uses: Mozilla-Actions/sccache-action@v0.0.5
+
+      - name: Configure cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Clean docs folder
+        run: cargo clean --doc
+
+      - name: Build docs
+        run: cargo doc -p verso -p libservo --no-deps
+
+      - name: Remove lock file
+        run: rm target/doc/.lock
+
+      - name: Upload `doc`
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc
+          path: target/doc
+
+  deploy:
+    if: github.repository_owner == 'versotile-org'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout `docs` repository
+        uses: actions/checkout@v4
+        with:
+          repository: versotile-org/docs.versotile.org
+          ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          ref: docs
+
+      - name: Clean up docs directory
+        run: |
+          cp {docs/,}index.html
+          rm -r docs/*
+          mv index.html docs/
+
+      - name: Download `doc`
+        uses: actions/download-artifact@v4
+        with:
+          name: doc
+          path: docs
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Commit and push
+        run: |
+          git add docs
+          git commit -m ":rocket: update docs from \`verso\` repository"
+          git push origin docs


### PR DESCRIPTION
By issue https://github.com/versotile-org/verso/issues/22

Fairly stable CI feature added.

It will deploy to the [docs](https://github.com/versotile-org/docs.versotile.org/tree/docs) repository on the branch `docs`...
... and the docs will be on the site https://docs.versotile.org/verso

Now, while it is tested and worked, after the wipe github experiencing some issues with github pages, so deploy should wait a little bit: [gh-issue](https://github.com/orgs/community/discussions/130206)

Some more improvement also possible, i.e.:
https://github.com/versotile-org/verso/issues/60