### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Nightly releases built with CrabNebula Cloud can be found at [releases](https://
 
 ## Future Work
 
-- Multiwindow support.
+- Multi-window support.
 - Enable multiprocess mode.
 - Enable sandbox in all platforms.
 - Enable `Gstreamer` feature.


### PR DESCRIPTION
Change the text `multiwindow` to `multi-window`. This change ensures clarity in the terminology used throughout the project.