### PR TITLE
chore: remove painting order method in compositor

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -45,7 +45,6 @@ use webrender_traits::{
 use winit::window::WindowId;
 
 use crate::touch::{TouchAction, TouchHandler};
-use crate::webview::WebView;
 use crate::window::Window;
 
 /// Data used to construct a compositor.
@@ -116,9 +115,6 @@ pub struct IOCompositor {
 
     /// The pixel density of the display.
     scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
-
-    /// The order to paint webviews in, top most webview should be the last element.
-    painting_order: Vec<WebView>,
 
     /// The active webrender document.
     webrender_document: DocumentId,
@@ -390,7 +386,6 @@ impl IOCompositor {
             pending_frames: 0,
             last_animation_tick: Instant::now(),
             is_animating: false,
-            painting_order: vec![],
         };
 
         // Make sure the GL state is OK
@@ -514,7 +509,7 @@ impl IOCompositor {
             }
 
             CompositorMsg::CreateOrUpdateWebView(frame_tree) => {
-                self.create_or_update_webview(&frame_tree);
+                self.create_or_update_webview(&frame_tree, windows);
                 self.send_scroll_positions_to_layout_for_pipeline(&frame_tree.pipeline.id);
             }
 
@@ -1033,9 +1028,9 @@ impl IOCompositor {
     /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
     /// for each visible top-level browsing context, applying a transformation on the root for
     /// pinch zoom, page zoom, and HiDPI scaling.
-    fn send_root_pipeline_display_list(&mut self) {
+    pub fn send_root_pipeline_display_list(&mut self, window: &Window) {
         let mut transaction = Transaction::new();
-        self.send_root_pipeline_display_list_in_transaction(&mut transaction);
+        self.send_root_pipeline_display_list_in_transaction(&mut transaction, window);
         self.generate_frame(&mut transaction, RenderReasons::SCENE);
         self.webrender_api
             .send_transaction(self.webrender_document, transaction);
@@ -1044,7 +1039,11 @@ impl IOCompositor {
     /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
     /// for each visible top-level browsing context, applying a transformation on the root for
     /// pinch zoom, page zoom, and HiDPI scaling.
-    fn send_root_pipeline_display_list_in_transaction(&self, transaction: &mut Transaction) {
+    fn send_root_pipeline_display_list_in_transaction(
+        &self,
+        transaction: &mut Transaction,
+        window: &Window,
+    ) {
         // Every display list needs a pipeline, but we'd like to choose one that is unlikely
         // to conflict with our content pipelines, which start at (1, 1). (0, 0) is WebRender's
         // dummy pipeline, so we choose (0, 1).
@@ -1075,8 +1074,8 @@ impl IOCompositor {
 
         let root_clip_id = builder.define_clip_rect(zoom_reference_frame, scaled_viewport_rect);
         let clip_chain_id = builder.define_clip_chain(None, [root_clip_id]);
-        for webview in &self.painting_order {
-            if let Some((pipeline_id, true)) = self.webviews.get(&webview.webview_id) {
+        for webview in window.painting_order() {
+            if let Some((pipeline_id, _)) = self.webviews.get(&webview.webview_id) {
                 let scaled_webview_rect = webview.rect.to_f32() / zoom_factor;
                 builder.push_iframe(
                     LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),
@@ -1137,7 +1136,12 @@ impl IOCompositor {
         }
     }
 
-    fn create_or_update_webview(&mut self, frame_tree: &SendableFrameTree) {
+    fn create_or_update_webview(
+        &mut self,
+        frame_tree: &SendableFrameTree,
+
+        windows: &mut HashMap<WindowId, Window>,
+    ) {
         let pipeline_id = frame_tree.pipeline.id;
         let webview_id = frame_tree.pipeline.top_level_browsing_context_id;
         debug!(
@@ -1148,7 +1152,9 @@ impl IOCompositor {
             debug!("{webview_id}'s pipeline has changed from {old_pipeline} to {pipeline_id}");
         }
 
-        self.send_root_pipeline_display_list();
+        if let Some(window) = windows.get(&self.current_window) {
+            self.send_root_pipeline_display_list(window);
+        }
         self.create_or_update_pipeline_details_with_frame_tree(frame_tree, None);
         self.reset_scroll_tree_for_unattached_pipelines(frame_tree);
 
@@ -1169,7 +1175,6 @@ impl IOCompositor {
             let (webview, close_window) =
                 window.remove_webview(top_level_browsing_context_id, self);
             if let Some(webview) = webview {
-                self.set_painting_order(window);
                 if let Some((pipeline_id, _)) = self.webviews.remove(&webview.webview_id) {
                     self.remove_pipeline_details_recursively(pipeline_id);
                 }
@@ -1295,7 +1300,6 @@ impl IOCompositor {
                 });
                 self.current_window = window.id();
                 self.scale_factor = Scale::new(window.scale_factor() as f32);
-                self.painting_order.clear();
                 window.resize(window.size(), self);
             }
         }
@@ -1320,13 +1324,13 @@ impl IOCompositor {
 
     /// Handle the window scale factor event and return a boolean to tell embedder if it should further
     /// handle the scale factor event.
-    pub fn on_scale_factor_event(&mut self, scale_factor: f32) -> bool {
+    pub fn on_scale_factor_event(&mut self, scale_factor: f32, window: &Window) -> bool {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return false;
         }
 
         self.scale_factor = Scale::new(scale_factor);
-        self.update_after_zoom_or_hidpi_change();
+        self.update_after_zoom_or_hidpi_change(window);
         self.composite_if_necessary(CompositingReason::Resize);
         true
     }
@@ -1609,7 +1613,7 @@ impl IOCompositor {
             }));
     }
 
-    fn process_pending_scroll_events(&mut self) {
+    fn process_pending_scroll_events(&mut self, window: &Window) {
         // Batch up all scroll events into one, or else we'll do way too much painting.
         let mut combined_scroll_event: Option<ScrollEvent> = None;
         let mut combined_magnification = 1.0;
@@ -1672,7 +1676,7 @@ impl IOCompositor {
 
         let mut transaction = Transaction::new();
         if zoom_changed {
-            self.send_root_pipeline_display_list_in_transaction(&mut transaction);
+            self.send_root_pipeline_display_list_in_transaction(&mut transaction, window);
         }
 
         if let Some((pipeline_id, external_id, offset)) = scroll_result {
@@ -1806,17 +1810,17 @@ impl IOCompositor {
     }
 
     /// Handle zoom reset event
-    pub fn on_zoom_reset_window_event(&mut self) {
+    pub fn on_zoom_reset_window_event(&mut self, window: &Window) {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return;
         }
 
         self.page_zoom = Scale::new(1.0);
-        self.update_after_zoom_or_hidpi_change();
+        self.update_after_zoom_or_hidpi_change(window);
     }
 
     /// Handle zoom event in the window
-    pub fn on_zoom_window_event(&mut self, magnification: f32) {
+    pub fn on_zoom_window_event(&mut self, magnification: f32, window: &Window) {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return;
         }
@@ -1826,11 +1830,11 @@ impl IOCompositor {
                 .max(MIN_ZOOM)
                 .min(MAX_ZOOM),
         );
-        self.update_after_zoom_or_hidpi_change();
+        self.update_after_zoom_or_hidpi_change(window);
     }
 
-    fn update_after_zoom_or_hidpi_change(&mut self) {
-        for webview in &self.painting_order {
+    fn update_after_zoom_or_hidpi_change(&mut self, window: &Window) {
+        for webview in window.painting_order() {
             self.send_window_size_message_for_top_level_browser_context(
                 webview.rect,
                 webview.webview_id,
@@ -1838,7 +1842,7 @@ impl IOCompositor {
         }
 
         // Update the root transform in WebRender to reflect the new zoom.
-        self.send_root_pipeline_display_list();
+        self.send_root_pipeline_display_list(window);
     }
 
     /// Simulate a pinch zoom
@@ -2121,7 +2125,7 @@ impl IOCompositor {
     }
 
     /// Perform composition and related actions.
-    pub fn perform_updates(&mut self) -> bool {
+    pub fn perform_updates(&mut self, windows: &mut HashMap<WindowId, Window>) -> bool {
         if self.shutdown_state == ShutdownState::FinishedShuttingDown {
             return false;
         }
@@ -2147,7 +2151,9 @@ impl IOCompositor {
         let _ = self.rendering_context.make_gl_context_current();
 
         if !self.pending_scroll_zoom_events.is_empty() {
-            self.process_pending_scroll_events()
+            if let Some(window) = windows.get(&self.current_window) {
+                self.process_pending_scroll_events(window)
+            }
         }
         self.shutdown_state != ShutdownState::FinishedShuttingDown
     }
@@ -2205,28 +2211,6 @@ impl IOCompositor {
         self.generate_frame(&mut txn, RenderReasons::TESTING);
         self.webrender_api
             .send_transaction(self.webrender_document, txn);
-    }
-
-    /// Update the painting order of the compositor.
-    pub fn set_painting_order(&mut self, window: &Window) {
-        if self.current_window == window.id() {
-            let painting_order = window.painting_order();
-            self.painting_order = painting_order;
-            self.send_root_pipeline_display_list();
-            debug!(
-                "Verso Compositor sets painting order to {:?}'s painting order {:?}",
-                window.id(),
-                self.painting_order
-                    .iter()
-                    .map(|w| w.webview_id)
-                    .collect::<Vec<_>>()
-            );
-        } else {
-            warn!(
-                "Failed to set painting order due to {:?} is not the current window",
-                window.id()
-            );
-        }
     }
 }
 

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -508,7 +508,7 @@ impl Verso {
 
             if compositor.shutdown_state != ShutdownState::FinishedShuttingDown {
                 // Update compositor
-                compositor.perform_updates();
+                compositor.perform_updates(&mut self.windows);
             } else {
                 shutdown = true;
             }

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -54,7 +54,7 @@ impl Window {
         message: EmbedderMsg,
         sender: &Sender<ConstellationMsg>,
         clipboard: Option<&mut Clipboard>,
-        compositor: &mut IOCompositor,
+        _compositor: &mut IOCompositor,
     ) {
         log::trace!("Verso WebView {webview_id:?} is handling Embedder message: {message:?}",);
         match message {
@@ -71,7 +71,6 @@ impl Window {
                     self.id(),
                     w
                 );
-                compositor.set_webview_loaded(&w);
             }
             EmbedderMsg::LoadComplete => {
                 self.window.request_redraw();
@@ -128,7 +127,7 @@ impl Window {
         message: EmbedderMsg,
         sender: &Sender<ConstellationMsg>,
         clipboard: Option<&mut Clipboard>,
-        compositor: &mut IOCompositor,
+        _compositor: &mut IOCompositor,
     ) -> bool {
         log::trace!("Verso Panel {panel_id:?} is handling Embedder message: {message:?}",);
         match message {
@@ -145,7 +144,6 @@ impl Window {
                     self.id(),
                     w
                 );
-                compositor.set_webview_loaded(&w);
             }
             EmbedderMsg::LoadComplete => {
                 self.window.request_redraw();

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -72,7 +72,6 @@ impl Window {
                     w
                 );
                 compositor.set_webview_loaded(&w);
-                compositor.set_painting_order(self);
             }
             EmbedderMsg::LoadComplete => {
                 self.window.request_redraw();
@@ -147,7 +146,6 @@ impl Window {
                     w
                 );
                 compositor.set_webview_loaded(&w);
-                compositor.set_painting_order(self);
             }
             EmbedderMsg::LoadComplete => {
                 self.window.request_redraw();

--- a/src/window.rs
+++ b/src/window.rs
@@ -149,7 +149,7 @@ impl Window {
                 return self.resize(size.to_i32(), compositor);
             }
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                compositor.on_scale_factor_event(*scale_factor as f32);
+                compositor.on_scale_factor_event(*scale_factor as f32, self);
             }
             WindowEvent::CursorEntered { .. } => {
                 compositor.swap_current_window(self);
@@ -189,7 +189,7 @@ impl Window {
                 }
             }
             WindowEvent::TouchpadMagnify { delta, .. } => {
-                compositor.on_zoom_window_event(1.0 + *delta as f32);
+                compositor.on_zoom_window_event(1.0 + *delta as f32, self);
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {
                 // FIXME: Pixels per line, should be configurable (from browser setting?) and vary by zoom level.
@@ -299,8 +299,7 @@ impl Window {
             compositor.on_resize_webview_event(w.webview_id, rect);
         }
 
-        compositor.set_painting_order(self);
-
+        compositor.send_root_pipeline_display_list(self);
         need_resize
     }
 
@@ -354,13 +353,13 @@ impl Window {
     }
 
     /// Get the painting order of this window.
-    pub fn painting_order(&self) -> Vec<WebView> {
+    pub fn painting_order(&self) -> Vec<&WebView> {
         let mut order = vec![];
         if let Some(webview) = &self.webview {
-            order.push(webview.clone());
+            order.push(webview);
         }
         if let Some(panel) = &self.panel {
-            order.push(panel.clone());
+            order.push(panel);
         }
         order
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,9 +10,7 @@ use script_traits::{TouchEventType, WheelDelta, WheelMode};
 use surfman::Connection;
 use surfman::SurfaceType;
 use webrender_api::{
-    units::{
-        DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, LayoutVector2D,
-    },
+    units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePoint, LayoutVector2D},
     ScrollLocation,
 };
 use webrender_traits::RenderingContext;
@@ -146,7 +144,7 @@ impl Window {
             }
             WindowEvent::Resized(size) => {
                 let size = Size2D::new(size.width, size.height);
-                return self.resize(size.to_i32(), compositor);
+                return compositor.resize(size.to_i32(), self);
             }
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 compositor.on_scale_factor_event(*scale_factor as f32, self);
@@ -275,32 +273,6 @@ impl Window {
     /// Queues a Winit `WindowEvent::RedrawRequested` event to be emitted that aligns with the windowing system drawing loop.
     pub fn request_redraw(&self) {
         self.window.request_redraw()
-    }
-
-    /// Resize the rendering context and all web views. Return true if the compositor should repaint and present
-    /// after this.
-    pub fn resize(
-        &mut self,
-        size: Size2D<i32, DevicePixel>,
-        compositor: &mut IOCompositor,
-    ) -> bool {
-        let need_resize = compositor.on_resize_window_event(size);
-
-        if let Some(panel) = &mut self.panel {
-            let rect = DeviceIntRect::from_size(size);
-            panel.rect = rect;
-            compositor.on_resize_webview_event(panel.webview_id, rect);
-        }
-
-        if let Some(w) = &mut self.webview {
-            let mut rect = DeviceIntRect::from_size(size);
-            rect.min.y = rect.max.y.min(76);
-            w.rect = rect;
-            compositor.on_resize_webview_event(w.webview_id, rect);
-        }
-
-        compositor.send_root_pipeline_display_list(self);
-        need_resize
     }
 
     /// Size of the window that's used by webrender.


### PR DESCRIPTION
It seems better to call window's painting order directly to get the right order.
This PR also fixes #114 