### PR TITLE
docs: add bug_report.md template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐞 Bug
 about: File a bug/issue
-title: '[BUG] <title>'
+title: 'bug: <title>'
 labels: Bug, Needs Triage
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,8 +26,8 @@ Example: steps to reproduce the behavior:
 4. See error
 -->
 
-### Screenshots
-<!-- If applicable, add screenshots to help explain your problem. -->
+### Screenshots Or Videos
+<!-- If applicable, add screenshots or videos to help explain your problem. -->
 
 ### Environment:
 <!--

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: 🐞 Bug
 about: File a bug/issue
 title: 'bug: <title>'
-labels: Bug, Needs Triage
+labels: bug, needs triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: 🐞 Bug
+about: File a bug/issue
+title: '[BUG] <title>'
+labels: Bug, Needs Triage
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for the bug you encountered.
+-->
+
+### Current Behavior:
+<!-- A concise description of what you're experiencing. -->
+
+### Expected Behavior:
+<!-- A concise description of what you expected to happen. -->
+
+### Steps To Reproduce:
+<!--
+Example: steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+### Environment:
+<!--
+Example:
+- OS: Ubuntu 20.04
+- Node: 13.14.0
+- npm: 7.6.3
+-->
+
+### Anything else:
+<!--
+Links? References? Anything that will give us more context about the issue that you are encountering!
+-->


### PR DESCRIPTION
Closes #154

This adds a bug report template to let reporter list out steps to reproduce and their system info.