### PR TITLE
Automated the project setup with a single command for both Windows and Unix-based systems using Batch and Shell scripts.

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,24 @@
+@echo off
+REM Display a message to the user
+echo Setting up Verso on Windows...
+
+REM Install Scoop (if not installed)
+where scoop >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Scoop not found. Installing Scoop...
+    powershell -Command "Set-ExecutionPolicy RemoteSigned -scope CurrentUser"
+    powershell -Command "iwr -useb get.scoop.sh | iex"
+)
+
+REM Install required tools via Scoop
+scoop install git python llvm cmake curl
+
+REM Install Python dependencies
+pip install mako
+
+REM Build and run the project using Cargo
+cargo run
+
+REM Display completion message
+echo Setup complete. Press any key to exit.
+pause

--- a/setup.bat
+++ b/setup.bat
@@ -1,24 +1,31 @@
 @echo off
-REM Display a message to the user
-echo Setting up Verso on Windows...
-
-REM Install Scoop (if not installed)
-where scoop >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Scoop not found. Installing Scoop...
-    powershell -Command "Set-ExecutionPolicy RemoteSigned -scope CurrentUser"
-    powershell -Command "iwr -useb get.scoop.sh | iex"
+REM Ensure script is run as administrator
+net session >nul 2>&1
+if not %errorLevel% == 0 (
+    echo This script must be run as administrator.
+    pause
+    exit /b 1
 )
 
-REM Install required tools via Scoop
+REM Install Scoop if not already installed
+where scoop >nul 2>&1
+if %errorLevel% neq 0 (
+    echo Installing Scoop...
+    powershell -Command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force; iex (new-object net.webclient).downloadstring('https://get.scoop.sh')"
+    set PATH=%PATH%;%USERPROFILE%\scoop\shims
+)
+
+REM Install necessary tools using Scoop
+echo Installing dependencies...
 scoop install git python llvm cmake curl
 
 REM Install Python dependencies
+echo Installing Python dependencies...
 pip install mako
 
 REM Build and run the project using Cargo
+echo Building the project...
 cargo run
 
-REM Display completion message
 echo Setup complete. Press any key to exit.
 pause

--- a/setup.sh
+++ b/setup.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
-# Display a message to the user
-echo "Setting up Verso on Unix-based systems..."
 
-# Function to install packages on Linux and macOS
-install_packages() {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        echo "Detected Linux. Installing dependencies..."
-        if [ -x "$(command -v apt-get)" ]; then
-            sudo apt-get update
-            sudo apt-get install -y git python3-pip llvm cmake curl
-        elif [ -x "$(command -v yum)" ]; then
-            sudo yum install -y git python3-pip llvm cmake curl
-        fi
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        echo "Detected macOS. Installing dependencies via Homebrew..."
-        if ! command -v brew &> /dev/null; then
-            echo "Homebrew not found. Installing Homebrew..."
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        fi
-        brew install cmake pkg-config harfbuzz
-    else
-        echo "Unsupported OS: $OSTYPE"
-        exit 1
-    fi
-}
+# Ensure script is run as root
+if [ "$(id -u)" != "0" ]; then
+   echo "This script must be run as root (use sudo)." 
+   exit 1
+fi
 
-# Install necessary packages
-install_packages
+# Install necessary packages based on the package manager available
+if [ -x "$(command -v apt-get)" ]; then
+    echo "Detected Debian-based system. Installing dependencies using apt-get."
+    sudo apt-get update
+    sudo apt-get install -y git python3-pip llvm cmake curl
+
+elif [ -x "$(command -v yum)" ]; then
+    echo "Detected Red Hat-based system. Installing dependencies using yum."
+    sudo yum install -y git python3-pip llvm cmake curl
+
+elif [ -x "$(command -v pacman)" ]; then
+    echo "Detected Arch-based system. Installing dependencies using pacman."
+    sudo pacman -Sy --needed git python-pip llvm cmake curl
+
+elif [ -x "$(command -v brew)" ]; then
+    echo "Detected macOS. Installing dependencies using Homebrew."
+    brew install git python3 llvm cmake curl
+
+else
+    echo "Unsupported OS or package manager. Please install dependencies manually."
+    exit 1
+fi
 
 # Install Python dependencies
+echo "Installing Python dependencies..."
 pip3 install mako
 
 # Build and run the project using Cargo
+echo "Building the project..."
 cargo run
-
-# Display completion message
-echo "Setup complete."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Display a message to the user
+echo "Setting up Verso on Unix-based systems..."
+
+# Function to install packages on Linux and macOS
+install_packages() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        echo "Detected Linux. Installing dependencies..."
+        if [ -x "$(command -v apt-get)" ]; then
+            sudo apt-get update
+            sudo apt-get install -y git python3-pip llvm cmake curl
+        elif [ -x "$(command -v yum)" ]; then
+            sudo yum install -y git python3-pip llvm cmake curl
+        fi
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "Detected macOS. Installing dependencies via Homebrew..."
+        if ! command -v brew &> /dev/null; then
+            echo "Homebrew not found. Installing Homebrew..."
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        fi
+        brew install cmake pkg-config harfbuzz
+    else
+        echo "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+}
+
+# Install necessary packages
+install_packages
+
+# Install Python dependencies
+pip3 install mako
+
+# Build and run the project using Cargo
+cargo run
+
+# Display completion message
+echo "Setup complete."


### PR DESCRIPTION
Added batch and shell files (setup.bat for Windows and setup.sh for Unix-based systems) to streamline the setup process for the Verso project. These scripts handle the installation of all necessary dependencies, tools, and build processes, enabling users to set up and run the project with a single command on their respective systems.

Steps: 
1. Clone repo: git clone https://github.com/versotile-org/verso/
2. Navigate to repo: cd verso
3. run: setup.bat for windows and chmod +x setup.sh then ./setup.sh for unix based systems ( macOS, linux etc. )