### PR TITLE
Update servo e078353

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Install Cargo Packager
         if: ${{ github.event_name == 'schedule' }}
-        run: cargo +stable install cargo-packager
+        run: cargo install cargo-packager
 
       - name: Build
         run: |
@@ -250,7 +250,7 @@ jobs:
 
       - name: Install Cargo Packager
         if: ${{ github.event_name == 'schedule' }}
-        run: cargo +stable install cargo-packager
+        run: cargo install cargo-packager
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,12 +153,6 @@ jobs:
       - name: Install Rust
         uses: dsherret/rust-toolchain-file@v1
 
-      - name: Install Rust toolchain for packager
-        if: ${{ github.event_name == 'schedule' }}
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-
       - name: Install Python
         uses: actions/setup-python@v5
         with:
@@ -224,12 +218,6 @@ jobs:
 
       - name: Install Rust
         uses: dsherret/rust-toolchain-file@v1
-
-      - name: Install Rust toolchain for packager
-        if: ${{ github.event_name == 'schedule' }}
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,13 +193,13 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "0.3.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 [[package]]
 name = "background_hang_monitor"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "background_hang_monitor_api",
  "backtrace",
@@ -257,11 +257,10 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "ipc-channel",
- "lazy_static",
  "malloc_size_of",
  "malloc_size_of_derive",
  "parking_lot",
@@ -288,11 +287,10 @@ dependencies = [
 [[package]]
 name = "base"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
- "lazy_static",
  "malloc_size_of",
  "malloc_size_of_derive",
  "parking_lot",
@@ -333,7 +331,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.72",
+ "syn",
  "which",
 ]
 
@@ -400,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bluetooth"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "bitflags 2.6.0",
  "bluetooth_traits",
@@ -416,7 +414,7 @@ dependencies = [
 [[package]]
 name = "bluetooth_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "embedder_traits",
  "ipc-channel",
@@ -479,9 +477,9 @@ checksum = "28346c117b50270785fbc123bd6e4ecad20d0c6d5f43d081dc80a3abcc62be64"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 
 [[package]]
 name = "byteorder"
@@ -540,7 +538,7 @@ dependencies = [
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -579,13 +577,12 @@ dependencies = [
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "crossbeam-channel",
  "euclid",
  "ipc-channel",
- "lazy_static",
  "malloc_size_of",
  "malloc_size_of_derive",
  "pixels",
@@ -621,12 +618,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -774,7 +772,7 @@ dependencies = [
 [[package]]
 name = "compositing_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -804,7 +802,7 @@ dependencies = [
 [[package]]
 name = "constellation"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "background_hang_monitor",
  "background_hang_monitor_api",
@@ -891,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
@@ -942,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1029,7 +1027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1049,7 +1047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1061,7 +1059,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 [[package]]
 name = "d3d12"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=69eea63757f097bc0953e5ed607eefe1977f9efa#69eea63757f097bc0953e5ed607eefe1977f9efa"
+source = "git+https://github.com/gfx-rs/wgpu?rev=781b54a8b9cee1a2cb22bda565662edec52eb70e#781b54a8b9cee1a2cb22bda565662edec52eb70e"
 dependencies = [
  "bitflags 2.6.0",
  "libloading",
@@ -1088,7 +1086,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1099,7 +1097,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1110,19 +1108,16 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "data-url"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
-dependencies = [
- "matches",
-]
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "deny_public_fields"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
@@ -1139,12 +1134,12 @@ dependencies = [
 [[package]]
 name = "derive_common"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
@@ -1156,13 +1151,13 @@ checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "chrono",
@@ -1184,7 +1179,7 @@ dependencies = [
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "bitflags 2.6.0",
@@ -1217,7 +1212,7 @@ dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1241,7 +1236,7 @@ dependencies = [
  "serde",
  "smallvec",
  "strck_ident",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1279,7 +1274,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1303,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1311,20 +1306,20 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
 name = "domobject_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1377,14 +1372,13 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "embedder_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "cfg-if",
  "crossbeam-channel",
  "ipc-channel",
  "keyboard-types",
- "lazy_static",
  "log",
  "num-derive",
  "num-traits",
@@ -1419,26 +1413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0aac423d2d59cc8b22de1ebd0db7f8d07382b8189945c89ab882a1c659b5"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df9d0cef4b051baf3ef7f9b1674273dc78cd56e02cba60fa187f9c0ff4ff5e0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1530,14 +1504,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
+ "libredox 0.1.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1617,7 +1591,7 @@ dependencies = [
 [[package]]
 name = "fonts"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -1637,7 +1611,6 @@ dependencies = [
  "freetype-sys",
  "harfbuzz-sys",
  "ipc-channel",
- "lazy_static",
  "libc",
  "log",
  "malloc_size_of",
@@ -1669,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "fonts_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "ipc-channel",
  "malloc_size_of",
@@ -1717,7 +1690,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -1828,7 +1801,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2150,16 +2123,16 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+checksum = "0ff6858c1f7e2a470c5403091866fa95b36fe0dbac5d771f932c15e5ff1ee501"
 dependencies = [
  "log",
  "mac",
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2245,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.13.2"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "cookie 0.18.1",
  "headers",
@@ -2652,7 +2625,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -2753,9 +2726,9 @@ checksum = "76a49eaebc8750bcba241df1e1e47ebb51b81eb35c65e8f11ffa0aebac353f7f"
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2795,11 +2768,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2870,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2880,10 +2853,10 @@ dependencies = [
 [[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
@@ -2918,7 +2891,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "layout_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -2963,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "layout_thread_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "base",
@@ -2975,7 +2948,6 @@ dependencies = [
  "fxhash",
  "ipc-channel",
  "layout_2020",
- "lazy_static",
  "log",
  "malloc_size_of",
  "metrics",
@@ -3032,9 +3004,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "libflate"
@@ -3076,10 +3048,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.1.18"
+name = "libredox"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.5.1",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
 dependencies = [
  "cc",
  "libc",
@@ -3159,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -3195,15 +3178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44db74bde26fdf427af23f1d146c211aed857c59e3be750cf2617f6b0b05c94"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+checksum = "d581ff8be69d08a2efa23a959d81aa22b739073f749f067348bd4f4ba4b69195"
 dependencies = [
  "log",
  "phf 0.11.2",
@@ -3222,12 +3205,11 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 [[package]]
 name = "media"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "euclid",
  "fnv",
  "ipc-channel",
- "lazy_static",
  "log",
  "serde",
  "servo-media",
@@ -3283,7 +3265,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "fonts_traits",
@@ -3341,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
@@ -3369,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#dbffebd0937c14d3c73ce9be4798da15cb2f369d"
+source = "git+https://github.com/servo/mozjs#4f0724dd3b9b58120903ff6a1043e71e7c7b9eb1"
 dependencies = [
  "bindgen",
  "cc",
@@ -3381,8 +3363,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.0-4"
-source = "git+https://github.com/servo/mozjs#dbffebd0937c14d3c73ce9be4798da15cb2f369d"
+version = "0.128.0-8"
+source = "git+https://github.com/servo/mozjs#4f0724dd3b9b58120903ff6a1043e71e7c7b9eb1"
 dependencies = [
  "bindgen",
  "cc",
@@ -3399,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=69eea63757f097bc0953e5ed607eefe1977f9efa#69eea63757f097bc0953e5ed607eefe1977f9efa"
+source = "git+https://github.com/gfx-rs/wgpu?rev=781b54a8b9cee1a2cb22bda565662edec52eb70e#781b54a8b9cee1a2cb22bda565662edec52eb70e"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -3459,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "async-recursion",
  "async-tungstenite",
@@ -3484,7 +3466,6 @@ dependencies = [
  "hyper_serde",
  "imsz",
  "ipc-channel",
- "lazy_static",
  "libflate",
  "log",
  "malloc_size_of",
@@ -3521,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "content-security-policy",
@@ -3533,7 +3514,6 @@ dependencies = [
  "hyper_serde",
  "image 0.24.9",
  "ipc-channel",
- "lazy_static",
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -3614,7 +3594,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -3675,7 +3655,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -3931,9 +3911,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -3950,7 +3930,7 @@ version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "libredox",
+ "libredox 0.0.2",
 ]
 
 [[package]]
@@ -4032,7 +4012,7 @@ source = "git+https://github.com/servo/webrender?branch=0.65#c0bcdd024adac1297ce
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "synstructure",
  "unicode-xid",
 ]
@@ -4112,7 +4092,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -4150,7 +4130,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -4168,7 +4148,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pixels"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "euclid",
  "image 0.24.9",
@@ -4212,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -4222,7 +4202,7 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4267,7 +4247,7 @@ dependencies = [
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "ipc-channel",
  "libc",
@@ -4283,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -4369,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "range"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -4621,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.1.8"
+version = "2.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d777f59627453628a9a5be1ee8d948745b94b1dfc2d0c3099cbd9e08ab89e7c"
+checksum = "aeb7ac86243095b70a7920639507b71d51a63390d1ba26c4f60a552fbb914a37"
 dependencies = [
  "sdd",
 ]
@@ -4643,7 +4623,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -4669,7 +4649,6 @@ dependencies = [
  "domobject_derive",
  "embedder_traits",
  "encoding_rs",
- "enum-iterator",
  "euclid",
  "fnv",
  "fonts",
@@ -4685,7 +4664,6 @@ dependencies = [
  "itertools 0.13.0",
  "jstraceable_derive",
  "keyboard-types",
- "lazy_static",
  "libc",
  "log",
  "malloc_size_of",
@@ -4746,7 +4724,7 @@ dependencies = [
 [[package]]
 name = "script_layout_interface"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -4781,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "background_hang_monitor_api",
  "base",
@@ -4845,14 +4823,14 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
+checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
 
 [[package]]
 name = "selectors"
 version = "0.24.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "bitflags 2.6.0",
  "cssparser",
@@ -4878,9 +4856,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -4896,20 +4874,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -4951,7 +4929,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -4970,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -4983,7 +4961,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -5004,17 +4982,17 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -5028,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -5040,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -5049,12 +5027,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#45756bef67037ade0f4f0125d579fdc3f3d457c8"
+source = "git+https://github.com/servo/media#ed1d4c7c11c93e7e66afc0224fc15f70d6b1fe83"
 dependencies = [
  "lazy_static",
  "log",
@@ -5065,18 +5043,18 @@ dependencies = [
 [[package]]
 name = "servo_allocator"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "servo_arc"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5085,7 +5063,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5094,13 +5072,12 @@ dependencies = [
 [[package]]
 name = "servo_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "dirs-next",
  "embedder_traits",
  "euclid",
  "getopts",
- "lazy_static",
  "log",
  "num_cpus",
  "serde",
@@ -5115,18 +5092,18 @@ dependencies = [
 [[package]]
 name = "servo_config_plugins"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
 name = "servo_geometry"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "app_units",
  "euclid",
@@ -5138,9 +5115,8 @@ dependencies = [
 [[package]]
 name = "servo_rand"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
- "lazy_static",
  "log",
  "rand",
  "rand_core",
@@ -5151,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "servo_url"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "malloc_size_of",
  "malloc_size_of_derive",
@@ -5223,7 +5199,7 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 [[package]]
 name = "size_of_test"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "static_assertions",
 ]
@@ -5353,7 +5329,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 
 [[package]]
 name = "strck"
@@ -5406,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -5465,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "lazy_static",
 ]
@@ -5473,20 +5449,20 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "darling",
  "derive_common",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "app_units",
  "bitflags 2.6.0",
@@ -5509,9 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "surfman"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0fa3767391402bf43c1dd4a70bb76f0573856748f7c240e9180994cc3bc3bb"
+checksum = "a1b072a0248f8b24d843cc2899deb169ed76bda7ab8e554761f6efd888002f41"
 dependencies = [
  "bitflags 1.3.2",
  "cfg_aliases 0.1.1",
@@ -5559,20 +5535,9 @@ checksum = "e454d048db5527d000bfddb77bd072bbf3a1e2ae785f16d9bd116e07c2ab45eb"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5587,7 +5552,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -5610,22 +5575,22 @@ dependencies = [
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5672,7 +5637,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -5809,7 +5774,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -5822,13 +5787,13 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2024-07-16#e7ea820c1aaee5a40f95552477c22b48b04c21b4"
+source = "git+https://github.com/servo/stylo?branch=2024-07-16#947990669824c192736f63f982e38b7e62150688"
 dependencies = [
  "darling",
  "derive_common",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
@@ -5856,7 +5821,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -5918,9 +5883,9 @@ checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -6269,34 +6234,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6306,9 +6272,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6316,22 +6282,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wayland-backend"
@@ -6456,9 +6422,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6499,7 +6465,7 @@ dependencies = [
 [[package]]
 name = "webdriver_server"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "base64",
@@ -6527,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "webgpu"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "arrayvec",
  "base",
@@ -6617,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=28430ba#28430bad0e7a4d4c11710d61fbaf1c598bffa87d"
+source = "git+https://github.com/servo/servo.git?rev=e078353#e078353bf01aebe5703b29c68ac59304cf6414f7"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -6634,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#355dce2140012ac1535ff6f2cf87b60297556eb4"
+source = "git+https://github.com/servo/webxr#08a6d70ad408d5699cae92e7d7542b5064746c83"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -6648,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#355dce2140012ac1535ff6f2cf87b60297556eb4"
+source = "git+https://github.com/servo/webxr#08a6d70ad408d5699cae92e7d7542b5064746c83"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -6665,7 +6631,7 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 [[package]]
 name = "wgpu-core"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=69eea63757f097bc0953e5ed607eefe1977f9efa#69eea63757f097bc0953e5ed607eefe1977f9efa"
+source = "git+https://github.com/gfx-rs/wgpu?rev=781b54a8b9cee1a2cb22bda565662edec52eb70e#781b54a8b9cee1a2cb22bda565662edec52eb70e"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -6690,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=69eea63757f097bc0953e5ed607eefe1977f9efa#69eea63757f097bc0953e5ed607eefe1977f9efa"
+source = "git+https://github.com/gfx-rs/wgpu?rev=781b54a8b9cee1a2cb22bda565662edec52eb70e#781b54a8b9cee1a2cb22bda565662edec52eb70e"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -6732,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "22.0.0"
-source = "git+https://github.com/gfx-rs/wgpu?rev=69eea63757f097bc0953e5ed607eefe1977f9efa#69eea63757f097bc0953e5ed607eefe1977f9efa"
+source = "git+https://github.com/gfx-rs/wgpu?rev=781b54a8b9cee1a2cb22bda565662edec52eb70e#781b54a8b9cee1a2cb22bda565662edec52eb70e"
 dependencies = [
  "bitflags 2.6.0",
  "js-sys",
@@ -6774,7 +6740,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6832,7 +6798,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -6843,7 +6809,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -6888,6 +6854,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7244,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "xcursor"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d491ee231a51ae64a5b762114c3ac2104b967aadba1de45c86ca42cf051513b7"
+checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
 
 [[package]]
 name = "xi-unicode"
@@ -7281,9 +7256,9 @@ checksum = "539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601"
 
 [[package]]
 name = "xml5ever"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+checksum = "d7b906d34d867d216b2d79fb0e9470aaa7f4948ea86b44c27846efedd596076c"
 dependencies = [
  "log",
  "mac",
@@ -7322,7 +7297,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
@@ -7344,7 +7319,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]
@@ -7364,7 +7339,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
  "synstructure",
 ]
 
@@ -7398,7 +7373,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,28 +62,28 @@ surfman = { version = "0.9", features = ["chains", "sm-raw-window-handle-06"] }
 thiserror = "1.0"
 winit = { version = "0.30", features = ["rwh_06"] }
 # Servo repo crates
-base = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-bluetooth = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-canvas = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-compositing_traits = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-constellation = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-devtools = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-embedder_traits = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-fonts = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-media = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-net = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-profile = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-profile_traits = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-script = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-script_traits = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-servo_config = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-servo_geometry = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-servo_url = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-webdriver_server = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-webrender_traits = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
-webgpu = { git = "https://github.com/servo/servo.git", rev = "28430ba" }
+base = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+bluetooth = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+canvas = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+compositing_traits = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+constellation = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+devtools = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+embedder_traits = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+fonts = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+media = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+net = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+profile = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+profile_traits = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+script = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+script_traits = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+servo_config = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+servo_geometry = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+servo_url = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+webdriver_server = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+webrender_traits = { git = "https://github.com/servo/servo.git", rev = "e078353" }
+webgpu = { git = "https://github.com/servo/servo.git", rev = "e078353" }
 # Servo org crates
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.78"
+channel = "1.80.1"
 components = [
     # For support/crown
     "llvm-tools",


### PR DESCRIPTION
Rust toolchain is upgraded to 1.80.1 to be in sync with servo.

Closes #159 .