### PR TITLE
chore: maintenance

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -207,7 +207,7 @@ fn get_modifiers(mods: ModifiersState) -> Modifiers {
 
 /// Convert Winit's KeyEvent to Servo's KeyboardEvent
 pub fn keyboard_event_from_winit(input: &KeyEvent, state: ModifiersState) -> KeyboardEvent {
-    info!("winit keyboard input: {:?}", input);
+    info!("winit keyboard input: {input:?}");
     KeyboardEvent {
         state: match input.state {
             ElementState::Pressed => KeyState::Down,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // Prevent console window from appearing on Windows
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![deny(clippy::pedantic)]
 
 use verso::config::Config;
 use verso::{Result, Verso};
@@ -30,7 +31,7 @@ impl ApplicationHandler for App {
         }
     }
 
-    fn user_event(&mut self, event_loop: &event_loop::ActiveEventLoop, _: ()) {
+    fn user_event(&mut self, event_loop: &event_loop::ActiveEventLoop, (): ()) {
         if let Some(v) = self.verso.as_mut() {
             v.handle_servo_messages(event_loop);
         }

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -136,14 +136,9 @@ impl Verso {
         };
 
         // Create dev tools thread
-        let devtools_sender = if opts.devtools_server_enabled {
-            Some(devtools::start_server(
-                opts.devtools_port,
-                embedder_sender.clone(),
-            ))
-        } else {
-            None
-        };
+        let devtools_sender = opts
+            .devtools_server_enabled
+            .then(|| devtools::start_server(opts.devtools_port, embedder_sender.clone()));
 
         // Create Webrender threads
         let (mut webrender, webrender_api_sender) = {

--- a/src/webview.rs
+++ b/src/webview.rs
@@ -99,8 +99,7 @@ impl Window {
                     .map(|c| {
                         c.get_text().unwrap_or_else(|e| {
                             log::warn!(
-                                "Verso WebView {webview_id:?} failed to get clipboard content: {}",
-                                e
+                                "Verso WebView {webview_id:?} failed to get clipboard content: {e}"
                             );
                             String::new()
                         })
@@ -108,8 +107,7 @@ impl Window {
                     .unwrap_or_default();
                 if let Err(e) = sender.send(contents) {
                     log::warn!(
-                        "Verso WebView {webview_id:?} failed to send clipboard content: {}",
-                        e
+                        "Verso WebView {webview_id:?} failed to send clipboard content: {e}"
                     );
                 }
             }
@@ -117,8 +115,7 @@ impl Window {
                 if let Some(c) = clipboard {
                     if let Err(e) = c.set_text(text) {
                         log::warn!(
-                            "Verso WebView {webview_id:?} failed to set clipboard contents: {}",
-                            e
+                            "Verso WebView {webview_id:?} failed to set clipboard contents: {e}"
                         );
                     }
                 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -81,7 +81,7 @@ impl Window {
         }
         let (rendering_context, surface) = RenderingContext::create(&window, &gl_config)
             .expect("Failed to create rendering context");
-        log::trace!("Created rendering context for window {:?}", window);
+        log::trace!("Created rendering context for window {window:?}");
 
         let size = window.inner_size();
         let size = Size2D::new(size.width as i32, size.height as i32);
@@ -142,7 +142,7 @@ impl Window {
         match event {
             WindowEvent::RedrawRequested => {
                 if let Err(err) = compositor.rendering_context.present(&self.surface) {
-                    log::warn!("Failed to present surface: {:?}", err);
+                    log::warn!("Failed to present surface: {err:?}");
                 }
             }
             WindowEvent::Focused(focused) => {
@@ -247,7 +247,7 @@ impl Window {
             WindowEvent::ModifiersChanged(modifier) => self.modifiers_state.set(modifier.state()),
             WindowEvent::KeyboardInput { event, .. } => {
                 let event = keyboard_event_from_winit(event, self.modifiers_state.get());
-                log::trace!("Verso is handling {:?}", event);
+                log::trace!("Verso is handling {event:?}");
                 let msg = ConstellationMsg::Keyboard(event);
                 send_to_constellation(sender, msg);
             }


### PR DESCRIPTION
- clippy delints
- add `deny(clippy::pedantic)` to make lint warnings stricter
- make code more idiomatic
- improve logic in some places or partial rewrites