### PR TITLE
build(flatpak): fix flatpak apt dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Install flatpak dependencies
         if: ${{ github.event_name == 'schedule' }}
         run: |
+          sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install -y --noninteractive flathub org.freedesktop.Platform//23.08


### PR DESCRIPTION
It didn't update the apt, so it's trying to fetch outdated and removed dependency