### PR TITLE
refactor: set min window size to show all panel options

### DIFF
--- a/resources/components/prompt/prompt.css
+++ b/resources/components/prompt/prompt.css
@@ -10,8 +10,8 @@ body {
 .dialog {
   display: flex;
   background: #ffffff;
-  width: 400px;
-  min-height: 110px;
+  width: 300px;
+  min-height: 60px;
   max-height: 300px;
   flex-direction: column;
   align-items: center;
@@ -24,6 +24,6 @@ body {
 .msg {
   display: inline-block;
   width: 100%;
-  min-height: 90px;
+  min-height: 50px;
   text-align: center;
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,11 @@ fn parse_cli_args() -> Result<CliArgs, getopts::Fail> {
 
     let mut window_attributes = winit::window::Window::default_attributes();
 
+    // set min inner size
+    // should be at least able to show the whole control panel
+    // FIXME: url input has weird behavior that will expand lager when having long text
+    window_attributes = window_attributes.with_min_inner_size(dpi::LogicalSize::new(480, 72));
+
     let width = matches.opt_get::<u32>("width").unwrap_or_else(|e| {
         log::error!("Failed to parse width command line argument: {e}");
         None


### PR DESCRIPTION
follow up: #250

- slightly shrink the size of the prompt
- set min window size to at least show all panel UI