### PR TITLE
chore: lock build-linux runner at ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
   pr-fast-check:
     if: ${{ github.event_name == 'pull_request' }}
     name: Pull Request Fast Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
@@ -52,7 +52,6 @@ jobs:
   build-linux:
     if: ${{ github.event_name != 'pull_request' }}
     name: Build [Linux]
-    # ubuntu-lastest now runs on ubuntu-24.04, which will break the build
     runs-on: ubuntu-22.04
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,8 @@ jobs:
   build-linux:
     if: ${{ github.event_name != 'pull_request' }}
     name: Build [Linux]
-    runs-on: ubuntu-latest
+    # ubuntu-lastest now runs on ubuntu-24.04, which will break the build
+    runs-on: ubuntu-22.04
     env:
       RUSTC_WRAPPER: sccache
       CCACHE: sccache


### PR DESCRIPTION
`ubuntu-latest` now uses 24.04.1 which will break the build in #265 . We'll have to lock the ubuntu version for now and move with servo as they progress.