### PR TITLE
chore: bump servo to 8cd280c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "background_hang_monitor_api",
  "backtrace",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "ipc-channel",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "base"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "bluetooth"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "bitflags 2.8.0",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bluetooth_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "embedder_traits",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "compositing_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "constellation"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "background_hang_monitor",
  "background_hang_monitor_api",
@@ -1369,7 +1369,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 [[package]]
 name = "deny_public_fields"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "syn 2.0.98",
  "synstructure",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "chrono",
@@ -1422,7 +1422,7 @@ dependencies = [
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "bitflags 2.8.0",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "bitflags 2.8.0",
  "malloc_size_of",
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "domobject_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1622,7 +1622,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "embedder_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "cfg-if",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "fonts"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "fonts_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "malloc_size_of_derive",
  "range",
@@ -2909,7 +2909,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.13.2"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.0",
@@ -3567,7 +3567,7 @@ dependencies = [
 [[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "proc-macro2",
  "syn 2.0.98",
@@ -3605,7 +3605,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "layout_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -3649,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "layout_thread_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "app_units",
  "base",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "app_units",
  "cssparser",
@@ -3910,7 +3910,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 [[package]]
 name = "media"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "euclid",
  "fnv",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "ipc-channel",
@@ -4025,9 +4025,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4169,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "content-security-policy",
@@ -4897,7 +4897,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pixels"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "euclid",
  "image 0.24.9",
@@ -5059,7 +5059,7 @@ dependencies = [
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "ipc-channel",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "range"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "malloc_size_of_derive",
  "num-traits",
@@ -5361,9 +5361,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5437,7 +5437,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5546,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "script_bindings"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -5570,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "script_layout_interface"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -5605,7 +5605,7 @@ dependencies = [
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "background_hang_monitor_api",
  "base",
@@ -5657,7 +5657,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "servo_allocator"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -5862,7 +5862,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5871,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "servo_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "euclid",
  "log",
@@ -5895,7 +5895,7 @@ dependencies = [
 [[package]]
 name = "servo_config_macro"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5906,7 +5906,7 @@ dependencies = [
 [[package]]
 name = "servo_geometry"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "app_units",
  "euclid",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "servo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5950,7 +5950,7 @@ dependencies = [
 [[package]]
 name = "servo_rand"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -5964,7 +5964,7 @@ dependencies = [
 [[package]]
 name = "servo_url"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -6155,7 +6155,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 
 [[package]]
 name = "strck"
@@ -6229,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6287,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "lazy_static",
 ]
@@ -6295,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6307,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -6335,7 +6335,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "surfman"
 version = "0.9.8"
-source = "git+https://github.com/servo/surfman?rev=a8079ee2708619926d07c5a2088b8c9af99abdb3#a8079ee2708619926d07c5a2088b8c9af99abdb3"
+source = "git+https://github.com/servo/surfman?rev=300789ddbda45c89e9165c31118bf1c4c07f89f6#300789ddbda45c89e9165c31118bf1c4c07f89f6"
 dependencies = [
  "bitflags 2.8.0",
  "cfg_aliases",
@@ -6456,7 +6456,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "cc",
 ]
@@ -6615,7 +6615,7 @@ checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
 [[package]]
 name = "timers"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -6663,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#8af5d515a03bfca5d19fcaa541783327673a951e"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "webdriver_server"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "base64 0.22.1",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "webgpu"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "arrayvec",
  "base",
@@ -7549,7 +7549,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "base",
  "embedder_traits",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=84006ba#84006ba76d1d6d7f64104d4c708e83610d6938df"
+source = "git+https://github.com/servo/servo.git?rev=8cd280c#8cd280ca3b221712f8111851fccdc757e7fabce8"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,30 +72,30 @@ sparkle = "0.1.26"
 thiserror = "1.0"
 winit = { version = "0.30", features = ["rwh_06"] }
 # Servo repo crates
-background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "84006ba", features = ["sampler"] }
-base = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-bluetooth = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-canvas = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-compositing_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-constellation = { git = "https://github.com/servo/servo.git", rev = "84006ba", features = ["webgpu"] }
-devtools = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-embedder_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-fonts = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-media = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-net = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-net_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-profile = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-profile_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-script = { git = "https://github.com/servo/servo.git", rev = "84006ba", features = ["webgpu"] }
-script_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-servo_config = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-servo_geometry = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-servo_url = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-webdriver_server = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-webrender_traits = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
-webgpu = { git = "https://github.com/servo/servo.git", rev = "84006ba" }
+background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "8cd280c", features = ["sampler"] }
+base = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+bluetooth = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+canvas = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+compositing_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+constellation = { git = "https://github.com/servo/servo.git", rev = "8cd280c", features = ["webgpu"] }
+devtools = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+embedder_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+fonts = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+media = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+net = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+net_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+profile = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+profile_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+script = { git = "https://github.com/servo/servo.git", rev = "8cd280c", features = ["webgpu"] }
+script_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+servo_config = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+servo_geometry = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+servo_url = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+webdriver_server = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+webrender_traits = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
+webgpu = { git = "https://github.com/servo/servo.git", rev = "8cd280c" }
 # Servo org crates
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -12,14 +12,16 @@ use compositing_traits::{
     SendableFrameTree,
 };
 use crossbeam_channel::Sender;
-use embedder_traits::{Cursor, MouseButton, MouseEventType, TouchEventType, TouchId, WheelDelta};
+use embedder_traits::{
+    Cursor, InputEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent,
+    TouchEvent, TouchEventAction, TouchId,
+};
 use euclid::{vec2, Point2D, Scale, Size2D, Transform3D, Vector2D};
 use gleam::gl;
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use log::{debug, error, trace, warn};
 use profile_traits::time::{self as profile_time, ProfilerCategory};
 use profile_traits::{mem, time, time_profile};
-use script_traits::CompositorEvent::{MouseButtonEvent, MouseMoveEvent, TouchEvent, WheelEvent};
 use script_traits::{
     AnimationState, AnimationTickType, ScriptThreadMessage, ScrollState, WindowSizeData,
     WindowSizeType,
@@ -394,7 +396,7 @@ impl IOCompositor {
         }
     }
 
-    fn update_cursor(&mut self, result: CompositorHitTestResult) {
+    fn update_cursor(&mut self, result: &CompositorHitTestResult) {
         let cursor = match result.cursor {
             Some(cursor) if cursor != self.cursor => cursor,
             _ => return,
@@ -529,7 +531,7 @@ impl IOCompositor {
 
                 if recomposite_needed {
                     if let Some(result) = self.hit_test_at_point(self.cursor_pos) {
-                        self.update_cursor(result);
+                        self.update_cursor(&result);
                     }
                 }
 
@@ -545,20 +547,20 @@ impl IOCompositor {
                 }
             }
 
-            CompositorMsg::WebDriverMouseButtonEvent(mouse_event_type, mouse_button, x, y) => {
+            CompositorMsg::WebDriverMouseButtonEvent(action, button, x, y) => {
                 let dppx = self.device_pixels_per_page_pixel();
                 let point = dppx.transform_point(Point2D::new(x, y));
-                self.on_mouse_window_event_class(match mouse_event_type {
-                    MouseEventType::Click => MouseWindowEvent::Click(mouse_button, point),
-                    MouseEventType::MouseDown => MouseWindowEvent::MouseDown(mouse_button, point),
-                    MouseEventType::MouseUp => MouseWindowEvent::MouseUp(mouse_button, point),
-                });
+                self.dispatch_input_event(InputEvent::MouseButton(MouseButtonEvent {
+                    point,
+                    action,
+                    button,
+                }));
             }
 
             CompositorMsg::WebDriverMouseMoveEvent(x, y) => {
                 let dppx = self.device_pixels_per_page_pixel();
                 let point = dppx.transform_point(Point2D::new(x, y));
-                self.on_mouse_window_move_event_class(DevicePoint::new(point.x, point.y));
+                self.dispatch_input_event(InputEvent::MouseMove(MouseMoveEvent { point }));
             }
 
             CompositorMsg::PendingPaintMetric(pipeline_id, epoch) => {
@@ -1269,56 +1271,52 @@ impl IOCompositor {
         true
     }
 
-    /// Handle the mouse event in the window.
-    pub fn on_mouse_window_event_class(&mut self, mouse_window_event: MouseWindowEvent) {
+    /// Dispatch input event to constellation.
+    fn dispatch_input_event(&mut self, event: InputEvent) {
+        // Events that do not need to do hit testing are sent directly to the
+        // constellation to filter down.
+        let Some(point) = event.point() else {
+            return;
+        };
+
+        // If we can't find a pipeline to send this event to, we cannot continue.
+        let Some(result) = self.hit_test_at_point(point) else {
+            return;
+        };
+
+        self.update_cursor(&result);
+
+        if let Err(error) = self
+            .constellation_chan
+            .send(ConstellationMsg::ForwardInputEvent(event, Some(result)))
+        {
+            warn!("Sending event to constellation failed ({error:?}).");
+        }
+    }
+
+    /// Handle the input event in the window.
+    pub fn on_input_event(&mut self, event: InputEvent) {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return;
         }
-
         if self.convert_mouse_to_touch {
-            match mouse_window_event {
-                MouseWindowEvent::Click(_, _) => {}
-                MouseWindowEvent::MouseDown(_, p) => self.on_touch_down(TouchId(0), p),
-                MouseWindowEvent::MouseUp(_, p) => self.on_touch_up(TouchId(0), p),
+            match event {
+                InputEvent::MouseButton(event) => {
+                    match event.action {
+                        MouseButtonAction::Click => {}
+                        MouseButtonAction::Down => self.on_touch_down(TouchId(0), event.point),
+                        MouseButtonAction::Up => self.on_touch_up(TouchId(0), event.point),
+                    }
+                    return;
+                }
+                InputEvent::MouseMove(event) => {
+                    self.on_touch_move(TouchId(0), event.point);
+                    return;
+                }
+                _ => {}
             }
-            return;
         }
-
-        self.dispatch_mouse_window_event_class(mouse_window_event);
-    }
-
-    fn dispatch_mouse_window_event_class(&mut self, mouse_window_event: MouseWindowEvent) {
-        let point = match mouse_window_event {
-            MouseWindowEvent::Click(_, p) => p,
-            MouseWindowEvent::MouseDown(_, p) => p,
-            MouseWindowEvent::MouseUp(_, p) => p,
-        };
-
-        let Some(result) = self.hit_test_at_point(point) else {
-            // TODO: Notify embedder that the event failed to hit test to any webview.
-            // TODO: Also notify embedder if an event hits a webview but isn’t consumed?
-            return;
-        };
-
-        let (button, event_type) = match mouse_window_event {
-            MouseWindowEvent::Click(button, _) => (button, MouseEventType::Click),
-            MouseWindowEvent::MouseDown(button, _) => (button, MouseEventType::MouseDown),
-            MouseWindowEvent::MouseUp(button, _) => (button, MouseEventType::MouseUp),
-        };
-
-        let event_to_send = MouseButtonEvent(
-            event_type,
-            button,
-            result.point_in_viewport.to_untyped(),
-            Some(result.node.into()),
-            Some(result.point_relative_to_item),
-            button as u16,
-        );
-
-        let msg = ConstellationMsg::ForwardEvent(result.pipeline_id, event_to_send);
-        if let Err(e) = self.constellation_chan.send(msg) {
-            warn!("Sending event to constellation failed ({:?}).", e);
-        }
+        self.dispatch_input_event(event);
     }
 
     fn hit_test_at_point(&self, point: DevicePoint) -> Option<CompositorHitTestResult> {
@@ -1370,91 +1368,45 @@ impl IOCompositor {
             .collect()
     }
 
-    /// Handle mouse move event in the window.
-    pub fn on_mouse_window_move_event_class(&mut self, cursor: DevicePoint) {
-        if self.shutdown_state != ShutdownState::NotShuttingDown {
+    fn send_touch_event(&self, event: TouchEvent) {
+        let Some(result) = self.hit_test_at_point(event.point) else {
             return;
-        }
-
-        if self.convert_mouse_to_touch {
-            self.on_touch_move(TouchId(0), cursor);
-            return;
-        }
-
-        self.dispatch_mouse_window_move_event_class(cursor);
-    }
-
-    fn dispatch_mouse_window_move_event_class(&mut self, cursor: DevicePoint) {
-        let result = match self.hit_test_at_point(cursor) {
-            Some(result) => result,
-            None => return,
         };
 
-        self.cursor_pos = cursor;
-        let event = MouseMoveEvent(result.point_in_viewport, Some(result.node.into()), 0);
-        let msg = ConstellationMsg::ForwardEvent(result.pipeline_id, event);
-        if let Err(e) = self.constellation_chan.send(msg) {
+        let event = InputEvent::Touch(event);
+        if let Err(e) = self
+            .constellation_chan
+            .send(ConstellationMsg::ForwardInputEvent(event, Some(result)))
+        {
             warn!("Sending event to constellation failed ({:?}).", e);
-        }
-        self.update_cursor(result);
-    }
-
-    fn send_touch_event(
-        &self,
-        event_type: TouchEventType,
-        identifier: TouchId,
-        point: DevicePoint,
-    ) {
-        if let Some(result) = self.hit_test_at_point(point) {
-            let event = TouchEvent(
-                event_type,
-                identifier,
-                result.point_in_viewport,
-                Some(result.node.into()),
-            );
-            let msg = ConstellationMsg::ForwardEvent(result.pipeline_id, event);
-            if let Err(e) = self.constellation_chan.send(msg) {
-                warn!("Sending event to constellation failed ({:?}).", e);
-            }
-        }
-    }
-
-    fn send_wheel_event(&mut self, delta: WheelDelta, point: DevicePoint) {
-        if let Some(result) = self.hit_test_at_point(point) {
-            let event = WheelEvent(delta, result.point_in_viewport, Some(result.node.into()));
-            let msg = ConstellationMsg::ForwardEvent(result.pipeline_id, event);
-            if let Err(e) = self.constellation_chan.send(msg) {
-                warn!("Sending event to constellation failed ({:?}).", e);
-            }
         }
     }
 
     /// Handle touch event.
-    pub fn on_touch_event(
-        &mut self,
-        event_type: TouchEventType,
-        identifier: TouchId,
-        location: DevicePoint,
-    ) {
+    pub fn on_touch_event(&mut self, event: TouchEvent) {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return;
         }
 
-        match event_type {
-            TouchEventType::Down => self.on_touch_down(identifier, location),
-            TouchEventType::Move => self.on_touch_move(identifier, location),
-            TouchEventType::Up => self.on_touch_up(identifier, location),
-            TouchEventType::Cancel => self.on_touch_cancel(identifier, location),
+        match event.action {
+            TouchEventAction::Down => self.on_touch_down(event.id, event.point),
+            TouchEventAction::Move => self.on_touch_move(event.id, event.point),
+            TouchEventAction::Up => self.on_touch_up(event.id, event.point),
+            TouchEventAction::Cancel => self.on_touch_cancel(event.id, event.point),
         }
     }
 
-    fn on_touch_down(&mut self, identifier: TouchId, point: DevicePoint) {
-        self.touch_handler.on_touch_down(identifier, point);
-        self.send_touch_event(TouchEventType::Down, identifier, point);
+    fn on_touch_down(&mut self, id: TouchId, point: DevicePoint) {
+        self.touch_handler.on_touch_down(id, point);
+        self.send_touch_event(TouchEvent {
+            action: TouchEventAction::Down,
+            id,
+            point,
+        })
     }
 
-    fn on_touch_move(&mut self, identifier: TouchId, point: DevicePoint) {
-        match self.touch_handler.on_touch_move(identifier, point) {
+    fn on_touch_move(&mut self, id: TouchId, point: DevicePoint) {
+        match self.touch_handler.on_touch_move(id, point) {
             TouchAction::Scroll(delta) => self.on_scroll_window_event(
                 ScrollLocation::Delta(LayoutVector2D::from_untyped(delta.to_untyped())),
                 point.cast(),
@@ -1476,43 +1428,56 @@ impl IOCompositor {
                         event_count: 1,
                     }));
             }
-            TouchAction::DispatchEvent => {
-                self.send_touch_event(TouchEventType::Move, identifier, point);
-            }
+            TouchAction::DispatchEvent => self.send_touch_event(TouchEvent {
+                action: TouchEventAction::Move,
+                id,
+                point,
+            }),
             _ => {}
         }
     }
 
-    fn on_touch_up(&mut self, identifier: TouchId, point: DevicePoint) {
-        self.send_touch_event(TouchEventType::Up, identifier, point);
+    fn on_touch_up(&mut self, id: TouchId, point: DevicePoint) {
+        self.send_touch_event(TouchEvent {
+            action: TouchEventAction::Up,
+            id,
+            point,
+        });
 
-        if let TouchAction::Click = self.touch_handler.on_touch_up(identifier, point) {
+        if let TouchAction::Click = self.touch_handler.on_touch_up(id, point) {
             self.simulate_mouse_click(point);
         }
     }
 
-    fn on_touch_cancel(&mut self, identifier: TouchId, point: DevicePoint) {
+    fn on_touch_cancel(&mut self, id: TouchId, point: DevicePoint) {
         // Send the event to script.
-        self.touch_handler.on_touch_cancel(identifier, point);
-        self.send_touch_event(TouchEventType::Cancel, identifier, point);
+        self.touch_handler.on_touch_cancel(id, point);
+        self.send_touch_event(TouchEvent {
+            action: TouchEventAction::Cancel,
+            id,
+            point,
+        })
     }
 
     /// <http://w3c.github.io/touch-events/#mouse-events>
-    fn simulate_mouse_click(&mut self, p: DevicePoint) {
+    fn simulate_mouse_click(&mut self, point: DevicePoint) {
         let button = MouseButton::Left;
-        self.dispatch_mouse_window_move_event_class(p);
-        self.dispatch_mouse_window_event_class(MouseWindowEvent::MouseDown(button, p));
-        self.dispatch_mouse_window_event_class(MouseWindowEvent::MouseUp(button, p));
-        self.dispatch_mouse_window_event_class(MouseWindowEvent::Click(button, p));
-    }
-
-    /// Hit test and forward the wheel event to constellation.
-    pub fn on_wheel_event(&mut self, delta: WheelDelta, p: DevicePoint) {
-        if self.shutdown_state != ShutdownState::NotShuttingDown {
-            return;
-        }
-
-        self.send_wheel_event(delta, p);
+        self.dispatch_input_event(InputEvent::MouseMove(MouseMoveEvent { point }));
+        self.dispatch_input_event(InputEvent::MouseButton(MouseButtonEvent {
+            button,
+            action: MouseButtonAction::Down,
+            point,
+        }));
+        self.dispatch_input_event(InputEvent::MouseButton(MouseButtonEvent {
+            button,
+            action: MouseButtonAction::Up,
+            point,
+        }));
+        self.dispatch_input_event(InputEvent::MouseButton(MouseButtonEvent {
+            button,
+            action: MouseButtonAction::Click,
+            point,
+        }));
     }
 
     /// Handle scroll event.
@@ -1520,18 +1485,18 @@ impl IOCompositor {
         &mut self,
         scroll_location: ScrollLocation,
         cursor: DeviceIntPoint,
-        phase: TouchEventType,
+        action: TouchEventAction,
     ) {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
             return;
         }
 
-        match phase {
-            TouchEventType::Move => self.on_scroll_window_event(scroll_location, cursor),
-            TouchEventType::Up | TouchEventType::Cancel => {
+        match action {
+            TouchEventAction::Move => self.on_scroll_window_event(scroll_location, cursor),
+            TouchEventAction::Up | TouchEventAction::Cancel => {
                 self.on_scroll_window_event(scroll_location, cursor);
             }
-            TouchEventType::Down => {
+            TouchEventAction::Down => {
                 self.on_scroll_window_event(scroll_location, cursor);
             }
         }

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -520,7 +520,6 @@ impl Verso {
                             //         window.0.set_cursor_icon(cursor);
                             //     }
                             // }
-                            EmbedderMsg::ReadyToPresent(_) => {}
                             // TODO: Check devtools' prompt has WebViewId?
                             // EmbedderMsg::Prompt(_, definition, origin) => match origin {
                             //     // TODO: actually prompt the user with a dialog
@@ -584,6 +583,7 @@ impl Verso {
             EmbedderMsg::MoveTo(webview_id, _) => Some(webview_id),
             EmbedderMsg::ResizeTo(webview_id, _) => Some(webview_id),
             EmbedderMsg::Prompt(webview_id, _, _) => Some(webview_id),
+            EmbedderMsg::RequestAuthentication(webview_id, ..) => Some(webview_id),
             EmbedderMsg::ShowContextMenu(webview_id, _, _, _) => Some(webview_id),
             EmbedderMsg::AllowNavigationRequest(webview_id, _, _) => Some(webview_id),
             EmbedderMsg::AllowOpeningWebView(webview_id, _) => Some(webview_id),
@@ -612,8 +612,6 @@ impl Verso {
             EmbedderMsg::MediaSessionEvent(webview_id, _) => Some(webview_id),
             EmbedderMsg::OnDevtoolsStarted(_, _) => None,
             EmbedderMsg::RequestDevtoolsConnection(_) => None,
-            EmbedderMsg::ReadyToPresent(_) => None, // TODO: check if we need dispatch this message to each window
-            EmbedderMsg::EventDelivered(webview_id, _) => Some(webview_id),
             EmbedderMsg::PlayGamepadHapticEffect(webview_id, _, _, _) => Some(webview_id),
             EmbedderMsg::StopGamepadHapticEffect(webview_id, _, _) => Some(webview_id),
         }

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -3,8 +3,7 @@ use base::id::WebViewId;
 use compositing_traits::ConstellationMsg;
 use crossbeam_channel::Sender;
 use embedder_traits::{
-    CompositorEventVariant, EmbedderMsg, LoadStatus, PermissionPrompt, PermissionRequest,
-    PromptCredentialsInput, PromptDefinition, PromptResult, TraversalDirection,
+    AllowOrDeny, EmbedderMsg, LoadStatus, PromptDefinition, PromptResult, TraversalDirection,
 };
 use ipc_channel::ipc;
 use script_traits::webdriver_msg::{WebDriverJSResult, WebDriverScriptCommand};
@@ -82,6 +81,7 @@ impl Window {
             }
             EmbedderMsg::WebViewBlurred => {
                 self.focused_webview_id = None;
+                self.close_context_menu(sender);
             }
             EmbedderMsg::WebViewFocused(w) => {
                 self.focused_webview_id = Some(webview_id);
@@ -187,11 +187,6 @@ impl Window {
                     );
                 }
             }
-            EmbedderMsg::EventDelivered(_webview_id, event) => {
-                if let CompositorEventVariant::MouseButtonEvent = event {
-                    send_to_constellation(sender, ConstellationMsg::FocusWebView(webview_id));
-                }
-            }
             EmbedderMsg::ShowContextMenu(_webview_id, _sender, _title, _options) => {
                 // TODO: Implement context menu
             }
@@ -209,9 +204,6 @@ impl Window {
                         PromptDefinition::Input(message, default_value, prompt_sender) => {
                             prompt.input(sender, rect, message, Some(default_value), prompt_sender);
                         }
-                        PromptDefinition::Credentials(prompt_sender) => {
-                            prompt.http_basic_auth(sender, rect, prompt_sender);
-                        }
                     }
 
                     // save prompt in window to keep prompt_sender alive
@@ -221,30 +213,30 @@ impl Window {
                     log::error!("Failed to get WebView {webview_id:?} in this window.");
                 }
             }
-            EmbedderMsg::PromptPermission(_webview_id, prompt, prompt_sender) => {
+            EmbedderMsg::PromptPermission(_webview_id, feature, prompt_sender) => {
                 if let Some(tab) = self.tab_manager.tab(webview_id) {
-                    let message = match prompt {
-                        PermissionPrompt::Request(permission_name) => {
-                            format!(
-                                "This website would like to request permission for {:?}.",
-                                permission_name
-                            )
-                        }
-                        PermissionPrompt::Insecure(permission_name) => {
-                            format!(
-                                "This website would like to request permission for {:?}. However current connection is not secure. Do you want to proceed?",
-                                permission_name
-                            )
-                        }
-                    };
+                    let message = format!(
+                        "This website would like to request permission for {:?}.",
+                        feature
+                    );
 
                     let mut prompt = PromptDialog::new();
-                    prompt.yes_no(
+                    prompt.allow_deny(
                         sender,
                         tab.webview().rect,
                         message,
-                        PromptSender::PermissionSender(prompt_sender),
+                        PromptSender::AllowDenySender(prompt_sender),
                     );
+                    self.tab_manager.set_prompt(webview_id, prompt);
+                } else {
+                    log::error!("Failed to get WebView {webview_id:?} in this window.");
+                }
+            }
+            EmbedderMsg::RequestAuthentication(_webview_id, _url, _proxy, response_sender) => {
+                if let Some(tab) = self.tab_manager.tab(webview_id) {
+                    let mut prompt = PromptDialog::new();
+                    let rect = tab.webview().rect;
+                    prompt.http_basic_auth(sender, rect, response_sender);
                     self.tab_manager.set_prompt(webview_id, prompt);
                 } else {
                     log::error!("Failed to get WebView {webview_id:?} in this window.");
@@ -273,6 +265,7 @@ impl Window {
             }
             EmbedderMsg::WebViewBlurred => {
                 self.focused_webview_id = None;
+                self.close_context_menu(sender);
             }
             EmbedderMsg::WebViewFocused(webview_id) => {
                 self.focused_webview_id = Some(webview_id);
@@ -456,11 +449,6 @@ impl Window {
                     }
                 }
             }
-            EmbedderMsg::EventDelivered(_webview_id, event) => {
-                if let CompositorEventVariant::MouseButtonEvent = event {
-                    send_to_constellation(sender, ConstellationMsg::FocusWebView(panel_id));
-                }
-            }
             e => {
                 log::trace!("Verso Panel isn't supporting this message yet: {e:?}")
             }
@@ -569,40 +557,35 @@ impl Window {
                                 let _ = sender.send(None);
                             }
                         }
-                        PromptSender::PermissionSender(sender) => {
-                            let result: PermissionRequest = match msg.as_str() {
-                                "ok" | "yes" => PermissionRequest::Granted,
-                                "cancel" | "no" => PermissionRequest::Denied,
+                        PromptSender::AllowDenySender(sender) => {
+                            let result: AllowOrDeny = match msg.as_str() {
+                                "ok" | "yes" => AllowOrDeny::Allow,
+                                "cancel" | "no" => AllowOrDeny::Deny,
                                 _ => {
                                     log::error!("prompt result message invalid: {msg}");
-                                    PermissionRequest::Denied
+                                    AllowOrDeny::Deny
                                 }
                             };
                             let _ = sender.send(result);
                         }
                         PromptSender::HttpBasicAuthSender(sender) => {
-                            let canceled_auth = PromptCredentialsInput {
-                                username: None,
-                                password: None,
-                            };
-
                             if let Ok(HttpBasicAuthInputResult { action, auth }) =
                                 serde_json::from_str::<HttpBasicAuthInputResult>(&msg)
                             {
                                 match action.as_str() {
                                     "signin" => {
-                                        let _ = sender.send(auth);
+                                        let _ = sender.send(Some(auth));
                                     }
                                     "cancel" => {
-                                        let _ = sender.send(canceled_auth);
+                                        let _ = sender.send(None);
                                     }
                                     _ => {
-                                        let _ = sender.send(canceled_auth);
+                                        let _ = sender.send(None);
                                     }
                                 };
                             } else {
                                 log::error!("prompt result message invalid: {msg}");
-                                let _ = sender.send(canceled_auth);
+                                let _ = sender.send(None);
                             }
                         }
                     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,8 +4,8 @@ use base::id::WebViewId;
 use compositing_traits::ConstellationMsg;
 use crossbeam_channel::Sender;
 use embedder_traits::{
-    Cursor, EmbedderMsg, MouseButton, PermissionRequest, PromptCredentialsInput, PromptResult,
-    TouchEventType, TraversalDirection, WheelDelta, WheelMode,
+    AllowOrDeny, Cursor, EmbedderMsg, InputEvent, MouseButton, MouseButtonAction, MouseButtonEvent,
+    MouseMoveEvent, PromptResult, TouchEventAction, TraversalDirection, WheelMode,
 };
 use euclid::{Point2D, Size2D};
 use glutin::{
@@ -37,7 +37,7 @@ use winit::{
 };
 
 use crate::{
-    compositor::{IOCompositor, MouseWindowEvent},
+    compositor::IOCompositor,
     keyboard::keyboard_event_from_winit,
     rendering::{gl_config_picker, RenderingContext},
     tab::TabManager,
@@ -382,9 +382,13 @@ impl Window {
                 self.mouse_position.set(None);
             }
             WindowEvent::CursorMoved { position, .. } => {
-                let cursor: DevicePoint = DevicePoint::new(position.x as f32, position.y as f32);
+                let point: DevicePoint = DevicePoint::new(position.x as f32, position.y as f32);
                 self.mouse_position.set(Some(*position));
-                compositor.on_mouse_window_move_event_class(cursor);
+                forward_input_event(
+                    compositor,
+                    sender,
+                    InputEvent::MouseMove(MouseMoveEvent { point }),
+                );
 
                 // handle Windows and Linux non-decoration window resize cursor
                 #[cfg(any(linux, target_os = "windows"))]
@@ -396,8 +400,8 @@ impl Window {
                 }
             }
             WindowEvent::MouseInput { state, button, .. } => {
-                let position = match self.mouse_position.get() {
-                    Some(position) => Point2D::new(position.x as f32, position.y as f32),
+                let point = match self.mouse_position.get() {
+                    Some(point) => Point2D::new(point.x as f32, point.y as f32),
                     None => {
                         log::trace!("Mouse position is None, skipping MouseInput event.");
                         return;
@@ -442,11 +446,11 @@ impl Window {
                 /* handle Windows and Linux non-decoration window resize */
                 #[cfg(any(linux, target_os = "windows"))]
                 {
-                    if *state == ElementState::Pressed && *button == winit::event::MouseButton::Left
+                    if *state == ElementState::Pressed
+                        && *button == winit::event::MouseButton::Left
+                        && self.is_resizable()
                     {
-                        if self.is_resizable() {
-                            self.drag_resize_window();
-                        }
+                        self.drag_resize_window();
                     }
                 }
 
@@ -464,27 +468,39 @@ impl Window {
                     }
                 };
 
-                let event: MouseWindowEvent = match state {
-                    ElementState::Pressed => MouseWindowEvent::MouseDown(button, position),
+                let event: MouseButtonEvent = match state {
+                    ElementState::Pressed => MouseButtonEvent {
+                        point,
+                        action: MouseButtonAction::Down,
+                        button,
+                    },
                     ElementState::Released => {
                         self.resizing = false;
-                        MouseWindowEvent::MouseUp(button, position)
+                        MouseButtonEvent {
+                            point,
+                            action: MouseButtonAction::Up,
+                            button,
+                        }
                     }
                 };
-                compositor.on_mouse_window_event_class(event);
+                forward_input_event(compositor, sender, InputEvent::MouseButton(event));
 
                 // Winit didn't send click event, so we send it after mouse up
                 if *state == ElementState::Released {
-                    let event: MouseWindowEvent = MouseWindowEvent::Click(button, position);
-                    compositor.on_mouse_window_event_class(event);
+                    let event: MouseButtonEvent = MouseButtonEvent {
+                        point,
+                        action: MouseButtonAction::Click,
+                        button,
+                    };
+                    forward_input_event(compositor, sender, InputEvent::MouseButton(event));
                 }
             }
             WindowEvent::PinchGesture { delta, .. } => {
                 compositor.on_zoom_window_event(1.0 + *delta as f32, self);
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {
-                let position = match self.mouse_position.get() {
-                    Some(position) => position,
+                let point = match self.mouse_position.get() {
+                    Some(point) => point,
                     None => {
                         log::trace!("Mouse position is None, skipping MouseWheel event.");
                         return;
@@ -494,7 +510,7 @@ impl Window {
                 // FIXME: Pixels per line, should be configurable (from browser setting?) and vary by zoom level.
                 const LINE_HEIGHT: f32 = 38.0;
 
-                let (mut x, mut y, mode) = match delta {
+                let (mut x, mut y, _mode) = match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
                         (*x as f64, (*y * LINE_HEIGHT) as f64, WheelMode::DeltaLine)
                     }
@@ -504,12 +520,6 @@ impl Window {
                     }
                 };
 
-                // Wheel Event
-                compositor.on_wheel_event(
-                    WheelDelta { x, y, z: 0.0, mode },
-                    DevicePoint::new(position.x as f32, position.y as f32),
-                );
-
                 // Scroll Event
                 // Do one axis at a time.
                 if y.abs() >= x.abs() {
@@ -518,16 +528,16 @@ impl Window {
                     y = 0.0;
                 }
 
-                let phase: TouchEventType = match phase {
-                    TouchPhase::Started => TouchEventType::Down,
-                    TouchPhase::Moved => TouchEventType::Move,
-                    TouchPhase::Ended => TouchEventType::Up,
-                    TouchPhase::Cancelled => TouchEventType::Cancel,
+                let phase: TouchEventAction = match phase {
+                    TouchPhase::Started => TouchEventAction::Down,
+                    TouchPhase::Moved => TouchEventAction::Move,
+                    TouchPhase::Ended => TouchEventAction::Up,
+                    TouchPhase::Cancelled => TouchEventAction::Cancel,
                 };
 
                 compositor.on_scroll_event(
                     ScrollLocation::Delta(LayoutVector2D::new(x as f32, y as f32)),
-                    DeviceIntPoint::new(position.x as i32, position.y as i32),
+                    DeviceIntPoint::new(point.x as i32, point.y as i32),
                     phase,
                 );
             }
@@ -555,8 +565,7 @@ impl Window {
                 if self.handle_keyboard_shortcut(compositor, &event) {
                     return;
                 }
-                let msg = ConstellationMsg::Keyboard(webview_id, event);
-                send_to_constellation(sender, msg);
+                forward_input_event(compositor, sender, InputEvent::Keyboard(event));
             }
             e => log::trace!("Verso Window isn't supporting this window event yet: {e:?}"),
         }
@@ -951,14 +960,11 @@ impl Window {
                 PromptSender::InputSender(sender) => {
                     let _ = sender.send(None);
                 }
-                PromptSender::PermissionSender(sender) => {
-                    let _ = sender.send(PermissionRequest::Denied);
+                PromptSender::AllowDenySender(sender) => {
+                    let _ = sender.send(AllowOrDeny::Deny);
                 }
                 PromptSender::HttpBasicAuthSender(sender) => {
-                    let _ = sender.send(PromptCredentialsInput {
-                        username: None,
-                        password: None,
-                    });
+                    let _ = sender.send(None);
                 }
             }
         }
@@ -1081,4 +1087,21 @@ pub unsafe fn decorate_window(view: *mut AnyObject, _position: LogicalPosition<f
             | NSWindowStyleMask::Resizable
             | NSWindowStyleMask::Miniaturizable,
     );
+}
+
+/// Forward input event to compositor or constellation.
+fn forward_input_event(
+    compositor: &mut IOCompositor,
+    constellation_proxy: &Sender<ConstellationMsg>,
+    event: InputEvent,
+) {
+    // Events with a `point` first go to the compositor for hit testing.
+    if event.point().is_some() {
+        compositor.on_input_event(event);
+        return;
+    }
+
+    let _ = constellation_proxy.send(ConstellationMsg::ForwardInputEvent(
+        event, None, /* hit_test */
+    ));
 }


### PR DESCRIPTION
- To receive `contextmenu` event
- Linux WebView context menu is broken in this update because the `WebViewFocused` emits only when the mouse is clicking an element (such as \<input> or \<a>), so we can't close it properly. We used to focus webview by handling `EventDelivered` event, but it has been removed.

Will try to fix the issue in another PR.