### PR TITLE
fix(linux): close context menu

### DIFF
--- a/resources/components/context_menu.html
+++ b/resources/components/context_menu.html
@@ -3,14 +3,29 @@
     <style>
       body {
         font-family: Arial, Helvetica, sans-serif;
-        background: #dfdfdf;
-        width: 184px;
+        margin: 0;
+        padding: 0;
+      }
+      .window-mask {
+        position: absolute;
+        top: 0;
+        left: 0;
+        background: transparent;
+        width: 200%;
+        height: 200%;
+        z-index: 0;
       }
       .menu {
+        position: absolute;
         display: flex;
         flex-direction: column;
         align-items: center;
         justify-content: start;
+        background: #dfdfdf;
+        width: 184px;
+        padding: 10px 8px 10px 8px;
+        border-radius: 5px;
+        z-index: 1;
       }
       .menu-item {
         cursor: pointer;
@@ -39,15 +54,82 @@
     </style>
   </head>
   <body>
+    <div id="mask" class="window-mask"></div>
     <div id="menu" class="menu"></div>
   </body>
   <script>
     const menuEl = document.getElementById('menu');
+    const maskEl = document.getElementById('mask');
+
+    /* register event listener */
+
+    // prevent create context menu when context menu exists
+    document.oncontextmenu = (ev) => {
+      ev.preventDefault();
+    };
+
+    // close menu when click on mask
+    maskEl.onmousedown = (ev) => {
+      const msg = JSON.stringify({
+        id: null,
+        close: true,
+      });
+      window.prompt(`CONTEXT_MENU:${msg}`);
+    };
+
+    /* parse params */
 
     let url = URL.parse(window.location.href);
     let params = url.searchParams;
-
+    const pos = {
+      x: parseInt(params.get('pos_x')),
+      y: parseInt(params.get('pos_y')),
+    };
     const options = JSON.parse(params.get('items'));
+
+    /* calc menu position */
+
+    // Avoid overflow to the window, adjust position if necessary
+    let windowSize = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+    let menuSize = {
+      width: 200,
+      height: options.length * 30 + 20,
+    };
+    let overflow = {
+      x: pos.x + menuSize.width - windowSize.width,
+      y: pos.y + menuSize.height - windowSize.height,
+    };
+
+    if (overflow.x >= 0) {
+      // check if the menu can be shown on left side of the cursor
+      if (pos.x - menuSize.width >= 0) {
+        pos.x = Math.max(0, pos.x - menuSize.width);
+      } else {
+        // if menu can't fit to left side of the cursor,
+        // shift left the menu, but not less than zero.
+        // TODO: if still smaller than screen, should show scroller
+        pos.x = Math.max(0, pos.x - overflow.x);
+      }
+    }
+    if (overflow.y >= 0) {
+      // check if the menu can be shown above the cursor
+      if (pos.y - menuSize.height >= 0) {
+        pos.y = Math.max(0, pos.y - menuSize.height);
+      } else {
+        // if menu can't fit to top of the cursor
+        // shift up the menu, but not less than zero.
+        // TODO: if still smaller than screen, should show scroller
+        pos.y = Math.max(0, pos.y - overflow.y);
+      }
+    }
+
+    menuEl.style.left = `${pos.x}px`;
+    menuEl.style.top = `${pos.y}px`;
+
+    /* create menu items */
     for (option of options) {
       createMenuItem(option.id, option.label, option.enabled);
     }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1238,6 +1238,12 @@ impl IOCompositor {
                 self.on_resize_webview_event(prompt_id, content_size);
             }
         }
+        #[cfg(linux)]
+        if let Some(context_menu) = &mut window.context_menu {
+            let rect = DeviceIntRect::from_size(size);
+            context_menu.webview.rect = rect;
+            self.on_resize_webview_event(context_menu.webview.webview_id, rect);
+        }
 
         self.send_root_pipeline_display_list(window);
     }

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -189,6 +189,7 @@ impl Window {
             }
             EmbedderMsg::ShowContextMenu(_webview_id, _sender, _title, _options) => {
                 // TODO: Implement context menu
+                let _ = _sender.send(embedder_traits::ContextMenuResult::Dismissed);
             }
             EmbedderMsg::Prompt(_webview_id, prompt_type, _origin) => {
                 if let Some(tab) = self.tab_manager.tab(webview_id) {
@@ -265,7 +266,6 @@ impl Window {
             }
             EmbedderMsg::WebViewBlurred => {
                 self.focused_webview_id = None;
-                self.close_context_menu(sender);
             }
             EmbedderMsg::WebViewFocused(webview_id) => {
                 self.focused_webview_id = Some(webview_id);
@@ -329,8 +329,7 @@ impl Window {
                             let size = self.size();
                             let rect = DeviceIntRect::from_size(size);
                             let content_size = self.get_content_size(rect, true);
-                            let mut webview = WebView::new(webview_id, rect);
-                            webview.set_size(content_size);
+                            let webview = WebView::new(webview_id, content_size);
 
                             self.tab_manager.append_tab(webview, true);
 
@@ -487,6 +486,10 @@ impl Window {
                 }
                 _ => log::trace!("Verso context menu isn't supporting this prompt yet"),
             },
+            EmbedderMsg::ShowContextMenu(_webview_id, _sender, _title, _options) => {
+                // TODO: Implement context menu
+                let _ = _sender.send(embedder_traits::ContextMenuResult::Dismissed);
+            }
             e => {
                 log::trace!("Verso context menu isn't supporting this message yet: {e:?}")
             }

--- a/src/window.rs
+++ b/src/window.rs
@@ -331,6 +331,9 @@ impl Window {
                     .send(ConstellationMsg::SetWebViewThrottled(tab_id, false));
 
                 self.focused_webview_id = Some(tab_id);
+                let _ = compositor
+                    .constellation_chan
+                    .send(ConstellationMsg::FocusWebView(tab_id));
 
                 // update painting order immediately to draw the active tab
                 compositor.send_root_pipeline_display_list(self);
@@ -666,6 +669,12 @@ impl Window {
         Size2D::new(size.width as i32, size.height as i32)
     }
 
+    /// Size of the window, including the window decorations.
+    pub fn outer_size(&self) -> DeviceIntSize {
+        let size = self.window.outer_size();
+        Size2D::new(size.width as i32, size.height as i32)
+    }
+
     /// Get Winit window ID of the window.
     pub fn id(&self) -> WindowId {
         self.window.id()
@@ -869,11 +878,11 @@ impl Window {
     }
 
     /// Close window's context menu
-    pub(crate) fn close_context_menu(&self, _sender: &Sender<ConstellationMsg>) {
+    pub(crate) fn close_context_menu(&self, sender: &Sender<ConstellationMsg>) {
         #[cfg(linux)]
         if let Some(context_menu) = &self.context_menu {
             send_to_constellation(
-                _sender,
+                sender,
                 ConstellationMsg::CloseWebView(context_menu.webview().webview_id),
             );
         }
@@ -916,28 +925,33 @@ impl Window {
         event: crate::webview::context_menu::ContextMenuResult,
     ) {
         self.close_context_menu(sender);
-        if let Some(tab_id) = self.tab_manager.current_tab_id() {
-            match event.id.as_str() {
-                "back" => {
-                    send_to_constellation(
-                        sender,
-                        ConstellationMsg::TraverseHistory(tab_id, TraversalDirection::Back(1)),
-                    );
+        if let Some(id) = event.id {
+            if let Some(tab_id) = self.tab_manager.current_tab_id() {
+                match id.as_str() {
+                    "back" => {
+                        send_to_constellation(
+                            sender,
+                            ConstellationMsg::TraverseHistory(tab_id, TraversalDirection::Back(1)),
+                        );
+                    }
+                    "forward" => {
+                        send_to_constellation(
+                            sender,
+                            ConstellationMsg::TraverseHistory(
+                                tab_id,
+                                TraversalDirection::Forward(1),
+                            ),
+                        );
+                    }
+                    "reload" => {
+                        send_to_constellation(sender, ConstellationMsg::Reload(tab_id));
+                    }
+                    _ => {}
                 }
-                "forward" => {
-                    send_to_constellation(
-                        sender,
-                        ConstellationMsg::TraverseHistory(tab_id, TraversalDirection::Forward(1)),
-                    );
-                }
-                "reload" => {
-                    send_to_constellation(sender, ConstellationMsg::Reload(tab_id));
-                }
-                _ => {}
+            } else {
+                log::error!("No active webview to handle context menu event");
             }
-        } else {
-            log::error!("No active webview to handle context menu event");
-        }
+        };
     }
 }
 


### PR DESCRIPTION
- Fix in #277, context menu not able to close from `WebViewFocused` event
- Create a context menu with a window size mask under the menu. If the user clicks on the mask, we send a message back to Verso to close the context menu.
- Move menu position calculation into `context_menu.html`