### PR TITLE
feat: Support IME event

### DIFF
--- a/src/verso.rs
+++ b/src/verso.rs
@@ -23,7 +23,6 @@ use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use layout_thread_2020;
 use log::{Log, Metadata, Record};
-use media::{GlApi, GlContext, NativeDisplay, WindowGLContext};
 use net::resource_thread;
 use profile;
 use script::{self, JSEngineSetup};

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -127,7 +127,6 @@ impl Verso {
         // Reserving a namespace to create TopLevelBrowsingContextId.
         PipelineNamespace::install(PipelineNamespaceId(0));
         let (mut window, rendering_context) = Window::new(evl, window_settings);
-        window.window.set_ime_allowed(true);
         let event_loop_waker = Box::new(Waker(proxy));
         let opts = opts::get();
 

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -127,7 +127,7 @@ impl Verso {
         // Reserving a namespace to create TopLevelBrowsingContextId.
         PipelineNamespace::install(PipelineNamespaceId(0));
         let (mut window, rendering_context) = Window::new(evl, window_settings);
-
+        window.window.set_ime_allowed(true);
         let event_loop_waker = Box::new(Waker(proxy));
         let opts = opts::get();
 

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -288,6 +288,12 @@ impl Window {
                     log::error!("Failed to get WebView {webview_id:?} in this window.");
                 }
             }
+            EmbedderMsg::ShowIME(_webview_id, input_method_type, text, multiline, position) => {
+                self.show_ime(input_method_type, text, multiline, position);
+            }
+            EmbedderMsg::HideIME(_webview_id) => {
+                self.hide_ime();
+            }
             e => {
                 log::trace!("Verso WebView isn't supporting this message yet: {e:?}")
             }

--- a/src/window.rs
+++ b/src/window.rs
@@ -30,7 +30,7 @@ use webrender_api::{
 #[cfg(any(linux, target_os = "windows"))]
 use winit::window::ResizeDirection;
 use winit::{
-    dpi::PhysicalPosition,
+    dpi::{LogicalPosition, LogicalSize, PhysicalPosition},
     event::{ElementState, Ime, TouchPhase, WindowEvent},
     event_loop::ActiveEventLoop,
     keyboard::ModifiersState,
@@ -552,7 +552,7 @@ impl Window {
                                 data: text,
                             })),
                         );
-                    },
+                    }
                     Ime::Enabled => {
                         forward_input_event(
                             compositor,
@@ -572,7 +572,7 @@ impl Window {
                                 data: text.to_string(),
                             })),
                         );
-                    },
+                    }
                     Ime::Disabled => {
                         forward_input_event(
                             compositor,
@@ -864,6 +864,30 @@ impl Window {
         };
         self.window.set_cursor(winit_cursor);
     }
+
+    /// This method enables IME and set the IME cursor area of the window.
+    /// The position is in logical position so it'll scale according to screen scaling factor.
+    pub fn show_ime(
+        &self,
+        _input_method_typee: embedder_traits::InputMethodType,
+        _text: Option<(String, i32)>,
+        _multilinee: bool,
+        position: euclid::Box2D<i32, webrender_api::units::DevicePixel>,
+    ) {
+        self.window.set_ime_allowed(true);
+        self.window.set_ime_cursor_area(
+            LogicalPosition::new(position.min.x, position.min.y),
+            LogicalSize::new(
+                position.max.x - position.min.x,
+                position.max.y - position.min.y,
+            ),
+        );
+    }
+
+    /// This method disables IME of the window.
+    pub fn hide_ime(&self) {
+        self.window.set_ime_allowed(false);
+    }
 }
 
 // Context Menu methods
@@ -1135,8 +1159,6 @@ impl Window {
 use objc2::runtime::AnyObject;
 #[cfg(macos)]
 use raw_window_handle::{AppKitWindowHandle, RawWindowHandle};
-#[cfg(macos)]
-use winit::dpi::LogicalPosition;
 
 /// Window decoration for macOS.
 #[cfg(macos)]

--- a/src/window.rs
+++ b/src/window.rs
@@ -885,7 +885,7 @@ impl Window {
         self.window.set_ime_cursor_area(
             LogicalPosition::new(position.min.x, position.min.y + height as i32),
             LogicalSize::new(
-                position.max.x - position.min.x,
+                0,
                 position.max.y - position.min.y,
             ),
         );

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,7 +4,7 @@ use base::id::WebViewId;
 use compositing_traits::ConstellationMsg;
 use crossbeam_channel::Sender;
 use embedder_traits::{
-    AllowOrDeny, ContextMenuResult, Cursor, EmbedderMsg, InputEvent, MouseButton,
+    AllowOrDeny, ContextMenuResult, Cursor, EmbedderMsg, ImeEvent, InputEvent, MouseButton,
     MouseButtonAction, MouseButtonEvent, MouseMoveEvent, PromptResult, TouchEventType,
     TraversalDirection, WebResourceResponseMsg, WheelMode,
 };
@@ -15,7 +15,9 @@ use glutin::{
 };
 use glutin_winit::DisplayBuilder;
 use ipc_channel::ipc::IpcSender;
-use keyboard_types::{Code, CompositionEvent, CompositionState, KeyState, KeyboardEvent, Modifiers};
+use keyboard_types::{
+    Code, CompositionEvent, CompositionState, KeyState, KeyboardEvent, Modifiers,
+};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use muda::{Menu as MudaMenu, MenuEvent, MenuEventReceiver, MenuItem};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -875,8 +877,13 @@ impl Window {
         position: euclid::Box2D<i32, webrender_api::units::DevicePixel>,
     ) {
         self.window.set_ime_allowed(true);
+        let height: f64 = if self.tab_manager.count() > 1 {
+            PANEL_HEIGHT + TAB_HEIGHT + PANEL_PADDING
+        } else {
+            PANEL_HEIGHT + PANEL_PADDING
+        };
         self.window.set_ime_cursor_area(
-            LogicalPosition::new(position.min.x, position.min.y),
+            LogicalPosition::new(position.min.x, position.min.y + height as i32),
             LogicalSize::new(
                 position.max.x - position.min.x,
                 position.max.y - position.min.y,


### PR DESCRIPTION
This is an early implementation of IME support thus the draft state.

We need to explicitly enable IME support to winit window so that winit will pass [`ImeEvent`](https://docs.rs/winit/latest/winit/event/enum.Ime.html) with `set_ime_allowed`. We can pass this event matching Servo's own [`ImeEvent::Composition`](https://github.com/servo/servo/blob/73507f58e63b130d91fcf6f1da13e643b9c469d3/components/shared/embedder/input_events.rs#L179).
