### PR TITLE
chore: Bump servo to `47f6c50`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "app_units"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a46058e45b48cf55b729e4ae34007fa904ea70cfcf2a0fa21dacf1441e521c"
+checksum = "cc864acc81f608e316133cd6bfb67ac57c11503a8cd54c55a818dd6b506abee5"
 dependencies = [
  "num-traits",
  "serde",
@@ -370,9 +370,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
+checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "background_hang_monitor_api",
  "backtrace",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "ipc-channel",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "base"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "bluetooth"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "bitflags 2.8.0",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bluetooth_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "embedder_traits",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "compositing_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "constellation"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "background_hang_monitor",
  "background_hang_monitor_api",
@@ -1368,7 +1368,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 [[package]]
 name = "deny_public_fields"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "syn 2.0.98",
  "synstructure",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "chrono",
@@ -1421,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "bitflags 2.8.0",
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "bitflags 2.8.0",
  "malloc_size_of",
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "domobject_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1617,18 +1617,19 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "embedder_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "cfg-if",
  "crossbeam-channel",
+ "euclid",
  "http 1.2.0",
  "hyper_serde",
  "ipc-channel",
@@ -1640,6 +1641,7 @@ dependencies = [
  "serde",
  "servo_malloc_size_of",
  "servo_url",
+ "url",
  "webrender_api",
 ]
 
@@ -1695,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1862,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "fonts"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -1911,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "fonts_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "malloc_size_of_derive",
  "range",
@@ -2595,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2878,7 +2880,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -2930,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.13.2"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.0",
@@ -3457,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -3588,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "proc-macro2",
  "syn 2.0.98",
@@ -3626,7 +3628,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "layout_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -3670,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "layout_thread_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "app_units",
  "base",
@@ -3738,9 +3740,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -3766,7 +3768,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.9",
 ]
 
 [[package]]
@@ -3830,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lyon_geom"
@@ -3872,7 +3874,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "app_units",
  "cssparser",
@@ -3931,7 +3933,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 [[package]]
 name = "media"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "euclid",
  "fnv",
@@ -3939,6 +3941,7 @@ dependencies = [
  "log",
  "serde",
  "servo-media",
+ "servo_config",
  "webrender_api",
  "webrender_traits",
 ]
@@ -3999,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "ipc-channel",
@@ -4046,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4191,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -4255,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "content-security-policy",
@@ -4764,7 +4767,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall 0.5.9",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4918,7 +4921,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pixels"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "euclid",
  "image 0.24.9",
@@ -5080,11 +5083,12 @@ dependencies = [
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "ipc-channel",
  "libc",
+ "parking_lot",
  "profile_traits",
  "regex",
  "serde",
@@ -5098,7 +5102,7 @@ dependencies = [
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -5185,7 +5189,7 @@ dependencies = [
 [[package]]
 name = "range"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "malloc_size_of_derive",
  "num-traits",
@@ -5251,9 +5255,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -5315,15 +5319,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -5458,7 +5461,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5567,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "script_bindings"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -5591,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "script_layout_interface"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -5625,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "background_hang_monitor_api",
  "base",
@@ -5677,7 +5680,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "bitflags 2.8.0",
  "cssparser",
@@ -5702,9 +5705,9 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -5720,9 +5723,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5731,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -5871,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "servo_allocator"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -5882,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5891,7 +5894,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5900,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "servo_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "serde",
  "serde_json",
@@ -5912,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "servo_config_macro"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5923,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "servo_geometry"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "app_units",
  "euclid",
@@ -5935,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "servo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5965,7 +5968,7 @@ dependencies = [
 [[package]]
 name = "servo_rand"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -5979,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "servo_url"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -6068,15 +6071,15 @@ dependencies = [
 
 [[package]]
 name = "smallbitvec"
-version = "2.5.3"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3fc564a4b53fd1e8589628efafe57602d91bde78be18186b5f61e8faea470"
+checksum = "d31d263dd118560e1a492922182ab6ca6dc1d03a3bf54e7699993f31a4150e3f"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -6141,12 +6144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72d540d5c565dbe1f891d7e21ceb21d2649508306782f1066989fccb0b363d3"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6170,7 +6167,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 
 [[package]]
 name = "strck"
@@ -6209,9 +6206,9 @@ dependencies = [
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244292f3441c89febe5b5bdfbb6863aeaf4f64da810ea3050fd927b27b8d92ce"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -6244,7 +6241,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6302,7 +6299,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "lazy_static",
 ]
@@ -6310,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6322,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "app_units",
  "bitflags 2.8.0",
@@ -6441,9 +6438,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944a2a0b6070d217b69afb819f65f84ba093c43d627571fdac1c46f03a14d326"
+checksum = "50e3102cd96acfdb0b3f037cb06e9b40d3dca1d7c6e4742147441daf6f34e8a6"
 dependencies = [
  "arrayvec",
  "grid",
@@ -6453,9 +6450,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
@@ -6471,16 +6468,16 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -6630,7 +6627,7 @@ checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
 [[package]]
 name = "timers"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -6677,7 +6674,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6690,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-02-03#1977193ab231d89cf0f87ccc23c05e4ff67ee3fd"
+source = "git+https://github.com/servo/stylo?branch=2025-02-03#7eaabe1687ea6afa84c6d7d6b8c1b3466aa56a36"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6898,9 +6895,9 @@ checksum = "191ea6762cbcd705fbed8f58573fd6c654453ff3da60adb293d9f255bc92af8e"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uluru"
@@ -6925,9 +6922,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-properties"
@@ -7023,9 +7020,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
 dependencies = [
  "getrandom 0.3.1",
  "serde",
@@ -7449,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "webdriver_server"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
  "base64 0.22.1",
@@ -7478,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "webgpu"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "arrayvec",
  "base",
@@ -7572,15 +7569,19 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "base",
+ "dpi",
  "embedder_traits",
  "euclid",
  "gleam",
+ "glow",
+ "image 0.24.9",
  "ipc-channel",
  "libc",
  "log",
+ "raw-window-handle",
  "serde",
  "servo-media",
  "servo_geometry",
@@ -7592,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=9668886#966888615fa8f4bf6ff4edb8496b0545f33912e3"
+source = "git+https://github.com/servo/servo.git?rev=47f6c50#47f6c50dd9aa113c80409d8f9794cfc883335c61"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,30 +77,30 @@ sparkle = "0.1.26"
 thiserror = "1.0"
 winit = { version = "0.30", features = ["rwh_06"] }
 # Servo repo crates
-background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "9668886", features = ["sampler"] }
-base = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-bluetooth = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-canvas = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-compositing_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-constellation = { git = "https://github.com/servo/servo.git", rev = "9668886", features = ["webgpu"] }
-devtools = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-embedder_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-fonts = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-media = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-net = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-net_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-profile = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-profile_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-script = { git = "https://github.com/servo/servo.git", rev = "9668886", features = ["webgpu"] }
-script_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-servo_config = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-servo_geometry = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-servo_url = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-webdriver_server = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-webrender_traits = { git = "https://github.com/servo/servo.git", rev = "9668886" }
-webgpu = { git = "https://github.com/servo/servo.git", rev = "9668886" }
+background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "47f6c50", features = ["sampler"] }
+base = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+bluetooth = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+canvas = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+compositing_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+constellation = { git = "https://github.com/servo/servo.git", rev = "47f6c50", features = ["webgpu", "bluetooth"] }
+devtools = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+embedder_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+fonts = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+media = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+net = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+net_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+profile = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+profile_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+script = { git = "https://github.com/servo/servo.git", rev = "47f6c50", features = ["webgpu", "bluetooth"] }
+script_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50", features = ["bluetooth"] }
+servo_config = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+servo_geometry = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+servo_url = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+webdriver_server = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+webrender_traits = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
+webgpu = { git = "https://github.com/servo/servo.git", rev = "47f6c50" }
 # Servo org crates
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -217,8 +217,8 @@ impl TouchHandler {
     pub fn on_event_processed(&mut self, result: EventResult) {
         if let WaitingForScript = self.state {
             self.state = match result {
-                EventResult::DefaultPrevented => DefaultPrevented,
-                EventResult::DefaultAllowed => match self.touch_count() {
+                EventResult::DefaultPrevented(_) => DefaultPrevented,
+                EventResult::DefaultAllowed(_) => match self.touch_count() {
                     1 => Touching,
                     2 => Pinching,
                     _ => MultiTouch,

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -164,7 +164,7 @@ impl Window {
                             ),
                         ) {
                             Ok(_) => {
-                                request_map.insert(id, (request.url, sender));
+                                request_map.insert(id, (ServoUrl::from_url(request.url), sender));
                                 // We will handle a ToVersoMessage::WebResourceRequestResponse
                                 // and send the response through this sender there if the call succeed
                                 return;

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use compositing_traits::ConstellationMsg;
 use crossbeam_channel::Sender;
 use embedder_traits::{
     AllowOrDeny, ContextMenuResult, Cursor, EmbedderMsg, InputEvent, MouseButton,
-    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, PromptResult, TouchEventAction,
+    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, PromptResult, TouchEventType,
     TraversalDirection, WebResourceResponseMsg, WheelMode,
 };
 use euclid::{Point2D, Size2D};
@@ -511,11 +511,11 @@ impl Window {
                     y = 0.0;
                 }
 
-                let phase: TouchEventAction = match phase {
-                    TouchPhase::Started => TouchEventAction::Down,
-                    TouchPhase::Moved => TouchEventAction::Move,
-                    TouchPhase::Ended => TouchEventAction::Up,
-                    TouchPhase::Cancelled => TouchEventAction::Cancel,
+                let phase: TouchEventType = match phase {
+                    TouchPhase::Started => TouchEventType::Down,
+                    TouchPhase::Moved => TouchEventType::Move,
+                    TouchPhase::Ended => TouchEventType::Up,
+                    TouchPhase::Cancelled => TouchEventType::Cancel,
                 };
 
                 compositor.on_scroll_event(


### PR DESCRIPTION
This is a quite hefty update with `TouchEvents` and `EmbedderMsg` changes:

- `Opts.wait_for_stable_image` is introduced to replace `Opts. exit_after_load`.
- Shutdown related compositor handling is now triggered through `EmbedderMsg` instead of `CompositorMsg`.
- `TouchEventAction` is now renamed as `TouchEventType`.
- The `action` stored in `TouchEvent` is now named `event_type` with the type of  `TouchEventType` and with the changes of the `TouchEvent` struct the touch event handling has been restructured.
- `WebResourceResponseMsg::Body` has been reworked into `WebResourceResponseMsg::SendBodyData` which takes in `Vec<u8>` directly now.