### PR TITLE
Properly migrate `WebResourceRequested` handler

### DIFF
--- a/src/verso.rs
+++ b/src/verso.rs
@@ -23,7 +23,6 @@ use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use layout_thread_2020;
 use log::{Log, Metadata, Record};
-use media::{GlApi, GlContext, NativeDisplay, WindowGLContext};
 use net::resource_thread;
 use profile;
 use script::{self, JSEngineSetup};
@@ -457,7 +456,7 @@ impl Verso {
                     {
                         log::error!(
                             "Verso failed to send WebResourceRequested to controller: {error}"
-                        )
+                        );
                     } else {
                         return false;
                     }
@@ -690,18 +689,16 @@ impl Verso {
                         if let Some(response) = response.response {
                             let _ = sender
                                 .send(WebResourceResponseMsg::Start(
-                                    WebResourceResponse::new(url.into_url())
+                                    WebResourceResponse::new(url)
                                         .headers(response.headers().clone())
                                         .status_code(response.status()),
                                 ))
                                 .and_then(|_| {
                                     sender.send(WebResourceResponseMsg::SendBodyData(
-                                        response.body().to_vec(),
+                                        response.into_body(),
                                     ))
                                 })
-                                .and_then(|_| {
-                                    sender.send(WebResourceResponseMsg::SendBodyData(Vec::new()))
-                                });
+                                .and_then(|_| sender.send(WebResourceResponseMsg::FinishLoad));
                         } else {
                             let _ = sender.send(WebResourceResponseMsg::DoNotIntercept);
                         }

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -164,7 +164,7 @@ impl Window {
                             ),
                         ) {
                             Ok(_) => {
-                                request_map.insert(id, (ServoUrl::from_url(request.url), sender));
+                                request_map.insert(id, (request.url, sender));
                                 // We will handle a ToVersoMessage::WebResourceRequestResponse
                                 // and send the response through this sender there if the call succeed
                                 return;

--- a/src/window.rs
+++ b/src/window.rs
@@ -63,7 +63,7 @@ pub(crate) struct EventListeners {
     pub(crate) on_navigation_starting: bool,
     /// A id to request response sender map if the controller wants to get and handle web resource requests
     pub(crate) on_web_resource_requested:
-        Option<HashMap<uuid::Uuid, (ServoUrl, IpcSender<WebResourceResponseMsg>)>>,
+        Option<HashMap<uuid::Uuid, (url::Url, IpcSender<WebResourceResponseMsg>)>>,
     /// This is `true` if the controller wants to get and handle WindowEvent::CloseRequested
     pub(crate) on_close_requested: bool,
 }


### PR DESCRIPTION
Fix the regression about `on_web_resource_requested` from #284

So it turned out, the exit is still working just fine, but `on_web_resource_requested` broke