### PR TITLE
feat: add --help command line argument

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,4 +17,7 @@ pub enum Error {
     /// IPC errors.
     #[error(transparent)]
     IpcError(#[from] ipc_channel::ipc::IpcError),
+    /// Error parsing arguments (or `--help` was invoked).
+    #[error(transparent)]
+    ArgError(#[from] crate::config::ArgError),
 }

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -80,8 +80,11 @@ impl Verso {
     /// - Canvas: Enabled
     /// - Constellation: Enabled
     /// - Image Cache: Enabled
-    pub fn new(evl: &ActiveEventLoop, proxy: EventLoopProxy<EventLoopProxyMessage>) -> Self {
-        let config = Config::new();
+    pub fn new(
+        config: Config,
+        evl: &ActiveEventLoop,
+        proxy: EventLoopProxy<EventLoopProxyMessage>,
+    ) -> Self {
         let to_controller_sender = if let Some(ipc_channel) = &config.args.ipc_channel {
             let sender =
                 IpcSender::<ToControllerMessage>::connect(ipc_channel.to_string()).unwrap();


### PR DESCRIPTION
* Adds --help as a command line argument
* Command line arguments are parsed first (before opening a window)
* Invalid arguments cause an early exit (rather than running with default arguments)
* Errors are printed with Display (rather than rust's default `format!("Error: {error:?}")`)