### PR TITLE
Introduce `VersoBuilder` for more stable controller creation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -332,6 +332,7 @@ impl Config {
             None
         });
         window_attributes = window_attributes.with_visible(config.visible);
+        window_attributes = window_attributes.with_active(config.focused);
 
         let profiler_settings =
             config

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use servo_config::{
     prefs::Preferences,
 };
 use versoview_messages::ConfigFromController;
-use winit::window::WindowAttributes;
+use winit::window::{Fullscreen, WindowAttributes};
 
 /// Servo time profile settings
 #[derive(Clone, Debug)]
@@ -298,6 +298,7 @@ impl Config {
             maximized: !cli_args.no_maximized,
             position: cli_args.position.map(Into::into),
             inner_size: cli_args.inner_size.map(Into::into),
+            ..Default::default()
         })
     }
 
@@ -325,6 +326,12 @@ impl Config {
             window_attributes = window_attributes.with_inner_size(size);
         }
         window_attributes = window_attributes.with_maximized(config.maximized);
+        window_attributes = window_attributes.with_fullscreen(if config.fullscreen {
+            Some(Fullscreen::Borderless(None))
+        } else {
+            None
+        });
+        window_attributes = window_attributes.with_visible(config.visible);
 
         let profiler_settings =
             config

--- a/verso/src/builder.rs
+++ b/verso/src/builder.rs
@@ -5,6 +5,7 @@ use versoview_messages::{ConfigFromController, ProfilerSettings};
 use crate::VersoviewController;
 
 /// A builder for configuring and creating a `VersoviewController` instance.
+#[derive(Debug, Clone)]
 pub struct VersoBuilder(ConfigFromController);
 
 impl VersoBuilder {

--- a/verso/src/builder.rs
+++ b/verso/src/builder.rs
@@ -49,6 +49,12 @@ impl VersoBuilder {
         self
     }
 
+    /// Sets whether the window will be initially focused or not.
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.0.focused = focused;
+        self
+    }
+
     /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
     pub fn devtools_port(mut self, port: u16) -> Self {
         self.0.devtools_port = Some(port);

--- a/verso/src/builder.rs
+++ b/verso/src/builder.rs
@@ -1,0 +1,102 @@
+use dpi::{Position, Size};
+use std::path::{Path, PathBuf};
+use versoview_messages::{ConfigFromController, ProfilerSettings};
+
+use crate::VersoviewController;
+
+/// A builder for configuring and creating a `VersoviewController` instance.
+pub struct VersoBuilder(ConfigFromController);
+
+impl VersoBuilder {
+    /// Creates a new `VersoBuilder` with default settings.
+    pub fn new() -> Self {
+        Self(ConfigFromController::default())
+    }
+
+    /// Sets whether the control panel should be included.
+    pub fn with_panel(mut self, with_panel: bool) -> Self {
+        self.0.with_panel = with_panel;
+        self
+    }
+
+    /// Sets the initial window size.
+    pub fn inner_size(mut self, size: impl Into<Size>) -> Self {
+        self.0.inner_size = Some(size.into());
+        self
+    }
+
+    /// Sets the initial window position.
+    pub fn position(mut self, position: impl Into<Position>) -> Self {
+        self.0.position = Some(position.into());
+        self
+    }
+
+    /// Sets whether the window should start maximized.
+    pub fn maximized(mut self, maximized: bool) -> Self {
+        self.0.maximized = maximized;
+        self
+    }
+
+    /// Sets whether the window should be visible initially.
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.0.visible = visible;
+        self
+    }
+
+    /// Sets whether the window should start in fullscreen mode.
+    pub fn fullscreen(mut self, fullscreen: bool) -> Self {
+        self.0.fullscreen = fullscreen;
+        self
+    }
+
+    /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
+    pub fn devtools_port(mut self, port: u16) -> Self {
+        self.0.devtools_port = Some(port);
+        self
+    }
+
+    /// Sets the profiler settings.
+    pub fn profiler_settings(mut self, settings: ProfilerSettings) -> Self {
+        self.0.profiler_settings = Some(settings);
+        self
+    }
+
+    /// Overrides the user agent.
+    pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.0.user_agent = Some(user_agent.into());
+        self
+    }
+
+    /// Sets the script to run when the document starts loading.
+    // pub fn init_script(mut self, script: impl Into<String>) -> Self {
+    //     self.0.init_script = Some(script.into());
+    //     self
+    // }
+
+    /// Sets the directory to load user scripts from.
+    pub fn userscripts_directory(mut self, directory: impl Into<String>) -> Self {
+        self.0.userscripts_directory = Some(directory.into());
+        self
+    }
+
+    /// Sets the initial zoom level of the webview.
+    pub fn zoom_level(mut self, zoom: f32) -> Self {
+        self.0.zoom_level = Some(zoom);
+        self
+    }
+
+    /// Sets the resource directory path.
+    pub fn resources_directory(mut self, path: impl Into<PathBuf>) -> Self {
+        self.0.resources_directory = Some(path.into());
+        self
+    }
+
+    /// Builds the `VersoviewController` with the configured settings.
+    pub fn build(
+        self,
+        versoview_path: impl AsRef<Path>,
+        initial_url: url::Url,
+    ) -> VersoviewController {
+        VersoviewController::create(versoview_path, initial_url, self.0)
+    }
+}

--- a/verso/src/lib.rs
+++ b/verso/src/lib.rs
@@ -1,3 +1,6 @@
+mod builder;
+pub use builder::VersoBuilder;
+
 use dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use log::error;
 use std::{
@@ -6,7 +9,7 @@ use std::{
     process::Command,
     sync::{mpsc::Sender as MpscSender, Arc, Mutex},
 };
-pub use versoview_messages::ConfigFromController as VersoviewSettings;
+pub use versoview_messages::{ConfigFromController as VersoviewSettings, ProfilerSettings};
 use versoview_messages::{
     ToControllerMessage, ToVersoMessage, WebResourceRequest, WebResourceRequestResponse,
 };
@@ -46,7 +49,6 @@ impl VersoviewController {
     fn create(
         verso_path: impl AsRef<Path>,
         initial_url: url::Url,
-        // TODO: rework this into a builder
         mut settings: VersoviewSettings,
     ) -> Self {
         let path = verso_path.as_ref();
@@ -174,6 +176,7 @@ impl VersoviewController {
     }
 
     /// Create a new verso instance with custom settings and get the controller to it
+    #[deprecated = "Use VersoBuilder instead"]
     pub fn new_with_settings(
         verso_path: impl AsRef<Path>,
         initial_url: url::Url,

--- a/verso/src/lib.rs
+++ b/verso/src/lib.rs
@@ -175,16 +175,6 @@ impl VersoviewController {
         Self::create(verso_path, initial_url, VersoviewSettings::default())
     }
 
-    /// Create a new verso instance with custom settings and get the controller to it
-    #[deprecated = "Use VersoBuilder instead"]
-    pub fn new_with_settings(
-        verso_path: impl AsRef<Path>,
-        initial_url: url::Url,
-        settings: VersoviewSettings,
-    ) -> Self {
-        Self::create(verso_path, initial_url, settings)
-    }
-
     /// Exit
     pub fn exit(&self) -> Result<(), Box<ipc_channel::ErrorKind>> {
         self.sender.send(ToVersoMessage::Exit)

--- a/verso/src/main.rs
+++ b/verso/src/main.rs
@@ -1,18 +1,14 @@
 use std::{env::current_exe, thread::sleep, time::Duration};
 
-use verso::VersoviewSettings;
-
 fn main() {
     let versoview_path = current_exe().unwrap().parent().unwrap().join("versoview");
-    let controller = verso::VersoviewController::new_with_settings(
-        versoview_path,
-        url::Url::parse("https://example.com").unwrap(),
-        VersoviewSettings {
-            with_panel: true,
-            maximized: true,
-            ..Default::default()
-        },
-    );
+    let controller = verso::VersoBuilder::new()
+        .with_panel(true)
+        .maximized(true)
+        .build(
+            versoview_path,
+            url::Url::parse("https://example.com").unwrap(),
+        );
     controller
         .on_navigation_starting(|url| {
             dbg!(url);

--- a/versoview_messages/src/lib.rs
+++ b/versoview_messages/src/lib.rs
@@ -116,6 +116,8 @@ pub struct ConfigFromController {
     pub visible: bool,
     /// Launch fullscreen or not for the initial winit window
     pub fullscreen: bool,
+    /// Launch focused or not for the initial winit window
+    pub focused: bool,
     /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
     pub devtools_port: Option<u16>,
     /// Servo time profile settings
@@ -142,6 +144,7 @@ impl Default for ConfigFromController {
             position: None,
             maximized: false,
             visible: true,
+            focused: true,
             fullscreen: false,
             devtools_port: None,
             profiler_settings: None,

--- a/versoview_messages/src/lib.rs
+++ b/versoview_messages/src/lib.rs
@@ -100,7 +100,7 @@ pub enum ToControllerMessage {
 }
 
 /// Configuration of Verso instance.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConfigFromController {
     /// URL to load initially.
     pub url: Option<url::Url>,
@@ -110,8 +110,12 @@ pub struct ConfigFromController {
     pub inner_size: Option<Size>,
     /// Window position for the initial winit window
     pub position: Option<Position>,
-    /// Window position for the initial winit window
+    /// Launch maximized or not for the initial winit window
     pub maximized: bool,
+    /// Launch visible or not for the initial winit window
+    pub visible: bool,
+    /// Launch fullscreen or not for the initial winit window
+    pub fullscreen: bool,
     /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
     pub devtools_port: Option<u16>,
     /// Servo time profile settings
@@ -127,6 +131,27 @@ pub struct ConfigFromController {
     /// Path to resource directory. If None, Verso will try to get default directory. And if that
     /// still doesn't exist, all resource configuration will set to default values.
     pub resources_directory: Option<PathBuf>,
+}
+
+impl Default for ConfigFromController {
+    fn default() -> Self {
+        Self {
+            url: None,
+            with_panel: false,
+            inner_size: None,
+            position: None,
+            maximized: false,
+            visible: true,
+            fullscreen: false,
+            devtools_port: None,
+            profiler_settings: None,
+            user_agent: None,
+            init_script: None,
+            userscripts_directory: None,
+            zoom_level: None,
+            resources_directory: None,
+        }
+    }
 }
 
 /// Servo time profile settings


### PR DESCRIPTION
#290 introduced a lot of initial settings and this PR adds in a builder as a more stable API to create verso controller with settings