### PR TITLE
chore: Bump servo to `ce4ba30`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "background_hang_monitor_api",
  "backtrace",
@@ -414,7 +414,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "ipc-channel",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "base"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -485,7 +485,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -512,7 +512,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.0",
  "shlex",
  "syn 2.0.99",
 ]
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "bluetooth"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "bitflags 2.9.0",
@@ -606,7 +606,7 @@ dependencies = [
 [[package]]
 name = "bluetooth_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "embedder_traits",
@@ -750,7 +750,7 @@ dependencies = [
  "bitflags 2.9.0",
  "log",
  "polling",
- "rustix 0.38.44",
+ "rustix",
  "slab",
  "thiserror 1.0.69",
 ]
@@ -762,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
- "rustix 0.38.44",
+ "rustix",
  "wayland-backend",
  "wayland-client",
 ]
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -1038,7 +1038,7 @@ dependencies = [
 [[package]]
 name = "compositing_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "constellation"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "background_hang_monitor",
  "background_hang_monitor_api",
@@ -1368,7 +1368,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 [[package]]
 name = "deny_public_fields"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "syn 2.0.99",
  "synstructure",
@@ -1398,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "chrono",
@@ -1421,7 +1421,7 @@ dependencies = [
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "bitflags 2.9.0",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "dom"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "bitflags 2.9.0",
  "malloc_size_of",
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "quote",
  "syn 2.0.99",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "domobject_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1624,7 +1624,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embedder_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "cfg-if",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "fonts"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "fonts_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "malloc_size_of_derive",
  "range",
@@ -2227,19 +2227,7 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "wasi",
 ]
 
 [[package]]
@@ -2601,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2757,14 +2745,16 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
 dependencies = [
  "log",
  "mac",
  "markup5ever",
- "match_token",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2853,9 +2843,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2884,7 +2874,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -2936,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.13.2"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.0",
@@ -3519,15 +3509,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3583,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3594,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "proc-macro2",
  "syn 2.0.99",
@@ -3632,7 +3613,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "layout_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -3677,7 +3658,7 @@ dependencies = [
 [[package]]
 name = "layout_thread_2020"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "app_units",
  "base",
@@ -3773,7 +3754,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.7",
 ]
 
 [[package]]
@@ -3812,12 +3793,6 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "litemap"
@@ -3885,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "app_units",
  "cssparser",
@@ -3925,17 +3900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.99",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,7 +3908,7 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 [[package]]
 name = "media"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "euclid",
  "fnv",
@@ -4013,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "ipc-channel",
@@ -4076,7 +4040,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -4094,10 +4058,11 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#2c59822b462e124edbd53418dd80fdd7ba038971"
+source = "git+https://github.com/servo/mozjs#87cabf4e9ddf9fafe19713a3d6bc8c5e6105544c"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
+ "lazy_static",
  "libc",
  "log",
  "mozjs_sys",
@@ -4106,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.6-1"
-source = "git+https://github.com/servo/mozjs#2c59822b462e124edbd53418dd80fdd7ba038971"
+source = "git+https://github.com/servo/mozjs#87cabf4e9ddf9fafe19713a3d6bc8c5e6105544c"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4158,7 +4123,7 @@ dependencies = [
  "spirv",
  "strum",
  "termcolor",
- "thiserror 2.0.12",
+ "thiserror 2.0.9",
  "unicode-ident",
 ]
 
@@ -4204,7 +4169,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -4268,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "content-security-policy",
@@ -4777,7 +4742,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4846,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -4931,7 +4896,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pixels"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "euclid",
  "image 0.24.9",
@@ -4983,7 +4948,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.44",
+ "rustix",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5093,7 +5058,7 @@ dependencies = [
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "ipc-channel",
@@ -5112,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -5184,7 +5149,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -5199,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "range"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "malloc_size_of_derive",
  "num-traits",
@@ -5265,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -5278,7 +5243,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -5297,7 +5262,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata 0.4.8",
  "regex-syntax",
 ]
 
@@ -5312,9 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5335,7 +5300,7 @@ checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -5367,9 +5332,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc_version"
@@ -5389,20 +5354,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.9.2",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -5484,7 +5436,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5593,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "script_bindings"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -5617,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "script_layout_interface"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -5651,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "background_hang_monitor_api",
  "base",
@@ -5703,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.26.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "bitflags 2.9.0",
  "cssparser",
@@ -5897,7 +5849,7 @@ dependencies = [
 [[package]]
 name = "servo_allocator"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -5908,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -5917,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "servo_atoms"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -5926,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "servo_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "serde",
  "serde_json",
@@ -5938,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "servo_config_macro"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5949,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "servo_geometry"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "app_units",
  "euclid",
@@ -5961,7 +5913,7 @@ dependencies = [
 [[package]]
 name = "servo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -5991,7 +5943,7 @@ dependencies = [
 [[package]]
 name = "servo_rand"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -6005,7 +5957,7 @@ dependencies = [
 [[package]]
 name = "servo_url"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -6120,7 +6072,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix 0.38.44",
+ "rustix",
  "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
@@ -6190,7 +6142,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "static_prefs"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 
 [[package]]
 name = "strck"
@@ -6264,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "style"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -6322,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "style_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "lazy_static",
 ]
@@ -6330,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "style_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6342,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "style_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "app_units",
  "bitflags 2.9.0",
@@ -6491,22 +6443,22 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.18.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom",
  "once_cell",
- "rustix 1.0.1",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -6548,11 +6500,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -6568,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6650,7 +6602,7 @@ checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
 [[package]]
 name = "timers"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -6697,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "to_shmem"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -6710,7 +6662,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-03-01#0190fff684fa7b67f5413a60f215e671b6222534"
+source = "git+https://github.com/servo/stylo?branch=2025-03-01#a93e7efd1b4ce73d5a1b3df2337f5d16d3de121e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6721,9 +6673,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7007,9 +6959,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7043,11 +6995,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom",
  "serde",
 ]
 
@@ -7202,7 +7154,7 @@ dependencies = [
  "futures-util",
  "headers 0.3.9",
  "http 0.2.12",
- "hyper 0.14.32",
+ "hyper 0.14.30",
  "log",
  "mime",
  "mime_guess",
@@ -7225,34 +7177,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
-dependencies = [
- "wit-bindgen-rt",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -7261,9 +7204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7274,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7284,9 +7227,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7297,12 +7240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wayland-backend"
@@ -7312,7 +7252,7 @@ checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.44",
+ "rustix",
  "scoped-tls",
  "smallvec",
  "wayland-sys 0.31.6",
@@ -7325,7 +7265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
 dependencies = [
  "bitflags 2.9.0",
- "rustix 0.38.44",
+ "rustix",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7347,7 +7287,7 @@ version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
 dependencies = [
- "rustix 0.38.44",
+ "rustix",
  "wayland-client",
  "xcursor",
 ]
@@ -7427,9 +7367,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7471,7 +7411,7 @@ dependencies = [
 [[package]]
 name = "webdriver_server"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "base64 0.22.1",
@@ -7500,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "webgpu"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "arrayvec",
  "base",
@@ -7594,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "webrender_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "base",
  "dpi",
@@ -7618,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=f3e6e4f#f3e6e4f04e1d692b2e56baa1cff4badbfb505d50"
+source = "git+https://github.com/servo/servo.git?rev=ce4ba30#ce4ba309924ffa35e0dd4309527586b8f0c22b75"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -7652,7 +7592,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.9",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
@@ -7720,7 +7660,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.9",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -7737,7 +7677,7 @@ dependencies = [
  "js-sys",
  "log",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.9",
  "web-sys",
 ]
 
@@ -7750,7 +7690,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.44",
+ "rustix",
 ]
 
 [[package]]
@@ -8109,7 +8049,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix 0.38.44",
+ "rustix",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -8145,15 +8085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -8237,7 +8168,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 0.38.44",
+ "rustix",
  "x11rb-protocol",
 ]
 
@@ -8249,12 +8180,13 @@ checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
- "rustix 1.0.1",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,30 +87,30 @@ bincode = { workspace = true }
 mime = "0.3"
 uuid = { workspace = true }
 # Servo repo crates
-background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f", features = ["sampler"] }
-base = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-bluetooth = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-canvas = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-compositing_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-constellation = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f", features = ["webgpu", "bluetooth"] }
-devtools = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-embedder_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-fonts = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-media = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-net = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-net_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-profile = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-profile_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-script = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f", features = ["webgpu", "bluetooth"] }
-script_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f", features = ["bluetooth"] }
-servo_config = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-servo_geometry = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-servo_url = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-webdriver_server = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-webrender_traits = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
-webgpu = { git = "https://github.com/servo/servo.git", rev = "f3e6e4f" }
+background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "ce4ba30", features = ["sampler"] }
+base = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+bluetooth = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+canvas = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+compositing_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+constellation = { git = "https://github.com/servo/servo.git", rev = "ce4ba30", features = ["webgpu", "bluetooth"] }
+devtools = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+embedder_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+fonts = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+layout_thread_2020 = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+media = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+net = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+net_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+profile = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+profile_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+script = { git = "https://github.com/servo/servo.git", rev = "ce4ba30", features = ["webgpu", "bluetooth"] }
+script_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30", features = ["bluetooth"] }
+servo_config = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+servo_geometry = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+servo_url = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+webdriver_server = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+webrender_traits = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
+webgpu = { git = "https://github.com/servo/servo.git", rev = "ce4ba30" }
 # Servo org crates
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -75,13 +75,17 @@ input[type="radio"]:checked::before { content: "●"; line-height: 1em; }
 
 input[type="file"]::before {
   content: "Choose File";
+  background: lightgrey;
+  border-top: solid 1px #EEEEEE;
+  border-left: solid 1px #CCCCCC;
+  border-right: solid 1px #999999;
+  border-bottom: solid 1px #999999;
 }
 
 input[type="file"] {
-  background: lightgrey;
   text-align: center;
-  vertical-align: middle;
   color: black;
+  border-style: none;
 }
 
 select {

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -122,7 +122,7 @@ impl Verso {
             &opts.time_profiling,
             opts.time_profiler_trace_path.clone(),
         );
-        let mem_profiler_sender = profile::mem::Profiler::create(opts.mem_profiler_period);
+        let mem_profiler_sender = profile::mem::Profiler::create();
 
         // Create compositor and embedder channels
         let (compositor_sender, compositor_receiver) = {


### PR DESCRIPTION
Several changes has been made, namely:

- Several constellation message now takes webview id
- `mem_profiler_period` is now obsolete
- upstream File Input changes has now been integrated