### PR TITLE
Add missing macOS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ cargo run
 - Install [Homebrew](https://brew.sh/) and then install other tools:
 
 ```sh
-brew install cmake pkg-config harfbuzz
-pip install mako
+brew install cmake pkg-config harfbuzz python@3 # Install required dependencies CMake, pkg-config, HarfBuzz, and Python 3.
+pip3 install mako # Install the Mako templating engine
+curl https://sh.rustup.rs -sSf | sh # Install Rust and Cargo
 ```
 
 - Build & run:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A web browser that plays old world blues to build new world hope.
 
-<img src="https://github.com/user-attachments/assets/ca124b2b-c54c-4796-b2cb-0819228495b6" width="600" />
+<img src="https://github.com/user-attachments/assets/ca124b2b-c54c-4796-b2cb-0819228495b6" width="600" alt="The Verso logo with a sitting cat, written in ASCII art, rendered in orange on black as on an old CRT monitor" />
 
 Verso is a web browser built on top of the [Servo](https://servo.org/) web engine. We aim to explore embedding solutions for Servo while growing it into a mature browser one day.
 This means we want to experiment with multi-view and multi-window first and then build UI elements entirely from Servo itself. At the moment, [Servoshell](https://servo.org/download/) should provide a better user experience.


### PR DESCRIPTION
First, thanks for starting this wonderful project! As I wanted to test it out, I tried following the README to build and run the application, but noticed a couple of missing dependencies. This PR adds them to the README file as well as a couple of other improvements listed below.

- Add alt attribute to `img` tag.
- Add Python 3 to the Homebrew dependencies.
- Change the `pip` command to `pip3` so it works with the installed
  Python version instead of depending on the system Python which comes
  without `pip` installed.
- Add command to install Rust and Cargo via RustUp.
- Add comments to the commands to explain what is installed.